### PR TITLE
Automate resource rolls

### DIFF
--- a/module/rolls.ts
+++ b/module/rolls.ts
@@ -6,6 +6,7 @@ import { handleAttrRoll } from "./rolls/rollAttribute.js";
 import { handleCirclesRoll } from "./rolls/rollCircles.js";
 import { handleLearningRoll } from "./rolls/rollLearning.js";
 import { handleGritRoll, handleShrugRoll } from "./rolls/rollPtgs.js";
+import { handleResourcesRoll } from "./rolls/rollResources.js";
 import { handleSkillRoll } from "./rolls/rollSkill.js";
 import { handleStatRoll } from "./rolls/rollStat.js";
 
@@ -21,8 +22,10 @@ export async function handleRollable(
             return handleStatRoll(target, sheet);
         case "circles":
             return handleCirclesRoll(target, sheet);
-        case "attribute": case "resources":
+        case "attribute":
             return handleAttrRoll(target, sheet);
+        case "resources":
+            return handleResourcesRoll(target, sheet);
         case "learning":
             return handleLearningRoll(target, sheet);
         case "shrug":
@@ -96,12 +99,20 @@ export function extractBaseData(html: JQuery<HTMLElement>, sheet: BWActorSheet )
     return { woundDice, obPenalty, diff, aDice, bDice, penaltySources, obstacleTotal };
 }
 
-export function extractString(html: JQuery<HTMLElement>, name: string): string {
+export function extractSelectString(html: JQuery<HTMLElement>, name: string): string | undefined {
+    return html.find(`select[name=\"${name}\"]`).val() as string;
+}
+
+export function extractSelectNumber(html: JQuery<HTMLElement>, name: string): number {
+    return parseInt(extractSelectString(html, name) || "0", 10) as number;
+}
+
+export function extractString(html: JQuery<HTMLElement>, name: string): string | undefined {
     return html.find(`input[name=\"${name}\"]`).val() as string;
 }
 
 export function extractNumber(html: JQuery<HTMLElement>, name: string): number {
-    return parseInt(extractString(html, name), 10);
+    return parseInt(extractString(html, name) || "0", 10);
 }
 
 export function extractForksValue(html: JQuery<HTMLElement>, name: string): number {
@@ -179,7 +190,9 @@ export const templates = {
     skillMessage: "systems/burningwheel/templates/chat/roll-message.html",
     statDialog: "systems/burningwheel/templates/chat/roll-dialog.html",
     statMessage: "systems/burningwheel/templates/chat/roll-message.html",
-    rerollChatMessage: "systems/burningwheel/templates/chat/fate-reroll-message.html"
+    rerollChatMessage: "systems/burningwheel/templates/chat/fate-reroll-message.html",
+    resourcesDialog: "systems/burningwheel/templates/chat/resources-dialog.html",
+    resourcesMessage: "systems/burningwheel/templates/chat/roll-message.html"
 };
 
 

--- a/module/rolls/rollAttribute.ts
+++ b/module/rolls/rollAttribute.ts
@@ -16,10 +16,6 @@ export async function handleAttrRoll(target: HTMLButtonElement, sheet: BWActorSh
     const stat = getProperty(sheet.actor.data, target.dataset.accessor || "") as Ability;
     const actor = sheet.actor as BWActor;
     const attrName = target.dataset.rollableName || "Unknown Attribute";
-    let tax = 0;
-    if (attrName === "Resources") {
-        tax = parseInt(actor.data.data.resourcesTax, 10);
-    }
     const data: AttributeDialogData = {
         name: `${attrName} Test`,
         difficulty: 3,
@@ -27,7 +23,6 @@ export async function handleAttrRoll(target: HTMLButtonElement, sheet: BWActorSh
         arthaDice: 0,
         woundDice: attrName === "Steel" ? actor.data.data.ptgs.woundDice : undefined,
         obPenalty: actor.data.data.ptgs.obPenalty,
-        tax,
         stat,
     };
 
@@ -40,7 +35,7 @@ export async function handleAttrRoll(target: HTMLButtonElement, sheet: BWActorSh
                 roll: {
                     label: "Roll",
                     callback: async (dialogHtml: JQuery<HTMLElement>) =>
-                        attrRollCallback(dialogHtml, stat, sheet, tax, attrName, target.dataset.accessor || "")
+                        attrRollCallback(dialogHtml, stat, sheet, attrName, target.dataset.accessor || "")
                 }
             }
         }).render(true)
@@ -51,15 +46,14 @@ async function attrRollCallback(
         dialogHtml: JQuery<HTMLElement>,
         stat: Ability,
         sheet: BWActorSheet,
-        tax: number,
         name: string,
         accessor: string) {
     const baseData = extractBaseData(dialogHtml, sheet);
     const exp = parseInt(stat.exp, 10);
-    const dieSources = buildDiceSourceObject(exp, baseData.aDice, baseData.bDice, 0, baseData.woundDice, tax);
-    const dg = helpers.difficultyGroup(exp + baseData.bDice - tax - baseData.woundDice, baseData.diff);
+    const dieSources = buildDiceSourceObject(exp, baseData.aDice, baseData.bDice, 0, baseData.woundDice, 0);
+    const dg = helpers.difficultyGroup(exp + baseData.bDice - baseData.woundDice, baseData.diff);
 
-    const numDice = exp + baseData.bDice + baseData.aDice - baseData.woundDice - tax;
+    const numDice = exp + baseData.bDice + baseData.aDice - baseData.woundDice;
     const roll = rollDice(numDice, stat.open, stat.shade);
     if (!roll) { return; }
 

--- a/module/rolls/rollResources.ts
+++ b/module/rolls/rollResources.ts
@@ -1,0 +1,123 @@
+import { Ability, BWActor } from "module/actor.js";
+import { BWActorSheet } from "module/bwactor-sheet.js";
+import * as helpers from "../helpers.js";
+import {
+    AttributeDialogData,
+    buildDiceSourceObject,
+    buildFateRerollData,
+    extractBaseData,
+    extractSelectNumber,
+    getRollNameClass,
+    RollChatMessageData,
+    rollDice,
+    templates,
+} from "../rolls.js";
+
+export async function handleResourcesRoll(_target: HTMLButtonElement, sheet: BWActorSheet): Promise<unknown> {
+    const stat = sheet.actor.data.data.resources;
+    const actor = sheet.actor as BWActor;
+    const data: ResourcesDialogData = {
+        name: "Resources Test",
+        difficulty: 3,
+        bonusDice: 0,
+        arthaDice: 0,
+        tax: parseInt(actor.data.data.resourcesTax, 10),
+        stat,
+        cashDieOptions: Array.from(Array(parseInt(actor.data.data.cash, 10) || 0).keys()),
+        fundDieOptions: Array.from(Array(parseInt(actor.data.data.funds, 10) || 0).keys())
+    };
+
+    const html = await renderTemplate(templates.resourcesDialog, data);
+    return new Promise(_resolve =>
+        new Dialog({
+            title: `Resources Test`,
+            content: html,
+            buttons: {
+                roll: {
+                    label: "Roll",
+                    callback: async (dialogHtml: JQuery<HTMLElement>) =>
+                        resourcesRollCallback(dialogHtml, stat, sheet)
+                }
+            }
+        }).render(true)
+    );
+}
+
+async function resourcesRollCallback(
+        dialogHtml: JQuery<HTMLElement>,
+        stat: Ability,
+        sheet: BWActorSheet) {
+    const baseData = extractBaseData(dialogHtml, sheet);
+    const cash = extractSelectNumber(dialogHtml, "cashDice");
+    const funds = extractSelectNumber(dialogHtml, "fundDice");
+    const tax = parseInt(sheet.actor.data.data.resourcesTax, 10) || 0;
+    const exp = parseInt(stat.exp, 10);
+    const dieSources = buildDiceSourceObject(exp, baseData.aDice, baseData.bDice, 0, 0, tax);
+
+    if (cash) {
+        dieSources["Cash Dice"] = `+${cash}`;
+        const currentCash = parseInt(sheet.actor.data.data.cash, 10) || 0;
+        sheet.actor.update({"data.cash": currentCash - cash});
+    }
+    if (funds) {
+        dieSources["Fund Dice"] = `+${funds}`;
+    }
+    const dg = helpers.difficultyGroup(
+        exp + baseData.bDice + cash + funds - tax,
+        baseData.diff + baseData.obPenalty);
+
+    const roll = rollDice(exp + baseData.bDice + baseData.aDice + cash + funds - tax, stat.open, stat.shade);
+    if (!roll) { return; }
+    const fateReroll = buildFateRerollData(sheet.actor, roll, "data.resources");
+    const isSuccess = parseInt(roll.result, 10) >= baseData.obstacleTotal;
+
+    const data: RollChatMessageData = {
+        name: 'Resources',
+        successes: roll.result,
+        difficulty: baseData.diff,
+        obstacleTotal: baseData.obstacleTotal,
+        nameClass: getRollNameClass(stat.open, stat.shade),
+        success: isSuccess,
+        rolls: roll.dice[0].rolls,
+        difficultyGroup: dg,
+        dieSources,
+        penaltySources: baseData.penaltySources,
+        fateReroll
+    };
+    const messageHtml = await renderTemplate(templates.resourcesMessage, data);
+
+    if (!isSuccess) {
+        const taxAmount = dg === "Challenging" ? (baseData.obstacleTotal - parseInt(roll.result, 10)) :
+            (dg === "Difficult" ? 2 : 1);
+        const taxMessage = new Dialog({
+            title: "Failed Resource Roll!",
+            content: `<p>You have failed a ${dg} Resource test.</p><p>How do you wish to be taxed?</p><hr/>`,
+            buttons: {
+                full: {
+                    label: `Full Tax (${taxAmount} tax)`,
+                    callback: () => sheet.actor.taxResources(taxAmount, funds)
+                },
+                cut: {
+                    label: "Cut your losses. (1 tax)",
+                    callback: () => sheet.actor.taxResources(1, funds)
+                },
+                skip: {
+                    label: "Skip for now"
+                }
+            }
+        });
+        taxMessage.render(true);
+    }
+
+    sheet.actor.addAttributeTest(stat, "Resources", "data.resources", dg, isSuccess);
+
+    return ChatMessage.create({
+        content: messageHtml,
+        speaker: ChatMessage.getSpeaker({actor: sheet.actor})
+    });
+}
+
+export interface ResourcesDialogData extends AttributeDialogData {
+    cashDieOptions: number[];
+    fundDieOptions: number[];
+}

--- a/styles/character/character.scss
+++ b/styles/character/character.scss
@@ -216,7 +216,7 @@
             }
 
             .attribute-value, .attribute-text {
-                font-size: 1.125;
+                font-size: 1.125em;
                 border: 0;
                 border-bottom: 1px solid black;
                 background-color: transparent;
@@ -229,7 +229,16 @@
             }
             .attribute-text {
                 width: 65%;
+                height: min-content;
                 border-radius: 0;
+                input {
+                    @include no-number-arrows;
+                    display: inline-block;
+                    background: rgba(black, .10);
+                    width: 2em;
+                    border: 0;
+                    text-align: center;
+                }
             }
         }
     }

--- a/template.yml
+++ b/template.yml
@@ -73,8 +73,8 @@ Actor:
         name: ''
       stride: 7
       mountedstride: 0
-      cash: ''
-      funds: ''
+      cash: 0
+      funds: 0
       property: ''
       loans: ''
       debt: ''

--- a/templates/character-sheet.html
+++ b/templates/character-sheet.html
@@ -179,11 +179,17 @@
             <br/>
             <div class="attributes-item flex-row">
                 <label class="debt-label">Cash</label>
-                <input type="text" class="attribute-text" name="data.cash" value="{{data.cash}}">
+                <div class="attribute-text">
+                    <input type="number" name="data.cash" value="{{data.cash}}" placeholder="0">
+                    Dice
+                </div>
             </div>
             <div class="attributes-item flex-row">
                 <label class="debt-label">Funds</label>
-                <input type="text" class="attribute-text" name="data.funds" value="{{data.funds}}">
+                <div class="attribute-text">
+                    <input type="number" name="data.funds" value="{{data.funds}}" placeholder="0">
+                    Dice
+                </div>
             </div>
             <div class="attributes-item flex-row">
                 <label class="debt-label">Property</label>

--- a/templates/chat/circles-dialog.html
+++ b/templates/chat/circles-dialog.html
@@ -5,18 +5,6 @@
             <label>Exponent</label>
             <input type="number" class="exponent" disabled name="stat.exp" value="{{stat.exp}}">
         </div>
-        {{#if woundDice}}
-        <div class="flex-row dialog-row">
-            <label>Wound Penalty</label>
-            <input type="number" class="exponent" disabled name="woundDice" value="{{woundDice}}">
-        </div>
-        {{/if}}
-        {{#if obPenalty}}
-        <div class="flex-row dialog-row">
-            <label>Ob Penalty</label>
-            <input type="number" class="exponent" disabled name="obPenalty" value="{{obPenalty}}">
-        </div>
-        {{/if}}
         {{#if circlesContact}}
         <div class="flex-row dialog-row">
             <label>Relationship Bonus</label>

--- a/templates/chat/resources-dialog.html
+++ b/templates/chat/resources-dialog.html
@@ -1,0 +1,53 @@
+<form class="dialog">
+    <h2>{{name}}</h2>
+    <div class="flex-row">
+        <div class="flex-row dialog-row">
+            <label>Exponent</label>
+            <input type="number" class="exponent" disabled name="stat.exp" value="{{stat.exp}}">
+        </div>
+        {{#if tax}}
+        <div class="flex-row dialog-row">
+            <label>Tax</label>
+            <input type="number" class="exponent" disabled name="tax" value="{{tax}}">
+        </div>
+        {{/if}}
+        <div class="flex-row dialog-row">
+            <label>Difficulty</label>
+            <input type="number" class="exponent" name="difficulty" value="{{difficulty}}">
+        </div>
+        <div class="flex-row dialog-row">
+            <label>Bonus Dice</label>
+            <input type="number" class="exponent" name="bonusDice" value="{{bonusDice}}">
+        </div>
+        <div class="flex-row dialog-row">
+            <label>Artha Dice</label>
+            <input type="number" class="exponent" name="arthaDice" value="{{arthaDice}}">
+        </div>
+        {{#if cashDieOptions}}
+        <div class="flex-row dialog-row">
+            <label>Cash Dice</label>
+            <select name="cashDice">
+                {{#select cashDice}}
+                <option value="0">0</option>
+                {{#each cashDieOptions as |o|}}
+                <option value="{{plusone o 1}}">{{plusone o 1}}</option>
+                {{/each}}
+                {{/select}}
+            </select>
+        </div>
+        {{/if}}
+        {{#if fundDieOptions}}
+        <div class="flex-row dialog-row">
+            <label>Fund Dice</label>
+            <select name="fundDice">
+                {{#select fundDice}}
+                <option value="0">0</option>
+                {{#each fundDieOptions as |o|}}
+                <option value="{{plusone o 1}}">{{plusone o 1}}</option>
+                {{/each}}
+                {{/select}}
+            </select>
+        </div>
+        {{/if}}
+    </div>
+</form>


### PR DESCRIPTION
Add option to use cash dice and funds in resources rolls.
Semi-automates tax (user prompts). Deducts from funds used first
Always removes cash dice used.

Changes cash and funds to be a number instead of a text entry field
in the character sheet.

Still missing support for fate re rolls to work correctly, but that whole setup melts my brain.

Resolves #34 - Resource roll automation