### PR TITLE
Add sheet settings section

### DIFF
--- a/module/character-sheet.ts
+++ b/module/character-sheet.ts
@@ -128,7 +128,8 @@ export class BWCharacterSheet extends BWActorSheet {
             ".reputation > i",
             ".affiliation > i",
             ".gear > div > i",
-            ".training-skill > div > i"
+            ".training-skill > div > i",
+            ".setting-item-row > div > i"
         ];
         html.find(selectors.join(", ")).click(e => this._manageItems(e));
 

--- a/module/helpers.ts
+++ b/module/helpers.ts
@@ -110,6 +110,12 @@ export async function sleep(ms: number) {
     return new Promise(r => setTimeout(r, ms));
 }
 
+export function isStat(name: string) {
+    return ([
+        "forte", "power", "will", "perception", "agility", "speed"
+    ].indexOf(name.toLowerCase()) !== -1);
+}
+
 const AbilityLookup = {
     "1": { r: 1, d: 1, c: 1},
     "2": { r: 2, d: 1, c: 1},

--- a/module/rolls/rerollCallon.ts
+++ b/module/rolls/rerollCallon.ts
@@ -1,5 +1,6 @@
 import { TestString } from "module/helpers.js";
 import { Ability, BWActor, TracksTests } from "../actor.js";
+import * as helpers from "../helpers.js";
 import { Skill, SkillData } from "../items/item.js";
 import { rollDice, templates } from "../rolls.js";
 
@@ -37,21 +38,23 @@ export async function handleCallonReroll(target: HTMLButtonElement): Promise<unk
                 updateData[`data.ptgs.${target.dataset.ptgsAction}`] = true;
                 actor.update(updateData);
             }
-            if (name === "Faith" || name === "Resources") {
-                actor.addAttributeTest(
-                    getProperty(actor, `data.${accessor}`) as TracksTests,
-                    name,
-                    accessor,
-                    target.dataset.difficultyGroup as TestString,
-                    true);
-            }
-            if (name === "Perception") {
-                actor.addStatTest(
-                    getProperty(actor, `data.${accessor}`) as TracksTests,
-                    name,
-                    accessor,
-                    target.dataset.difficultyGroup as TestString,
-                    true);
+            if (actor.data.successOnlyRolls.indexOf(name.toLowerCase()) !== -1) {
+                if (!helpers.isStat(name)) {
+                    actor.addAttributeTest(
+                        getProperty(actor, `data.${accessor}`) as TracksTests,
+                        name,
+                        accessor,
+                        target.dataset.difficultyGroup as TestString,
+                        true);
+                }
+                else {
+                    actor.addStatTest(
+                        getProperty(actor, `data.${accessor}`) as TracksTests,
+                        name,
+                        accessor,
+                        target.dataset.difficultyGroup as TestString,
+                        true);
+                }
             }
         }
 

--- a/module/rolls/rerollFate.ts
+++ b/module/rolls/rerollFate.ts
@@ -1,5 +1,6 @@
 import { TestString } from "module/helpers.js";
 import { Ability, BWActor, TracksTests } from "../actor.js";
+import * as helpers from "../helpers.js";
 import { Skill, SkillData } from "../items/item.js";
 import { RerollMessageData, rollDice, templates } from "../rolls.js";
 
@@ -45,21 +46,23 @@ export async function handleFateReroll(target: HTMLButtonElement): Promise<unkno
                 if (target.dataset.ptgsAction) { // shrug/grit flags may need to be set.
                     updateData[`data.ptgs.${target.dataset.ptgsAction}`] = true;
                 }
-                if (name === "Faith" || name === "Resources") {
-                    actor.addAttributeTest(
-                        getProperty(actor, `data.${accessor}`) as TracksTests,
-                        name,
-                        accessor,
-                        target.dataset.difficultyGroup as TestString,
-                        true);
-                }
-                if (name === "Perception") {
-                    actor.addStatTest(
-                        getProperty(actor, `data.${accessor}`) as TracksTests,
-                        name,
-                        accessor,
-                        target.dataset.difficultyGroup as TestString,
-                        true);
+                if (actor.data.successOnlyRolls.indexOf(name.toLowerCase()) !== -1) {
+                    if (!helpers.isStat(name)) {
+                        actor.addAttributeTest(
+                            getProperty(actor, `data.${accessor}`) as TracksTests,
+                            name,
+                            accessor,
+                            target.dataset.difficultyGroup as TestString,
+                            true);
+                    }
+                    else {
+                        actor.addStatTest(
+                            getProperty(actor, `data.${accessor}`) as TracksTests,
+                            name,
+                            accessor,
+                            target.dataset.difficultyGroup as TestString,
+                            true);
+                    }
                 }
             }
             actor.update(updateData);

--- a/module/rolls/rollSkill.ts
+++ b/module/rolls/rollSkill.ts
@@ -67,6 +67,7 @@ async function skillRollCallback(
     const callons: RerollData[] = sheet.actor.getCallons(skill.name).map(s => {
         return { label: s, ...buildRerollData(sheet.actor, roll, undefined, skill._id) as RerollData };
     });
+    const success = parseInt(roll.result, 10) >= baseData.obstacleTotal;
 
     const data: RollChatMessageData = {
         name: `${skill.name}`,
@@ -74,7 +75,7 @@ async function skillRollCallback(
         difficulty: baseData.diff,
         obstacleTotal: baseData.obstacleTotal,
         nameClass: getRollNameClass(skill.data.data.open, skill.data.data.shade),
-        success: parseInt(roll.result, 10) >= baseData.obstacleTotal,
+        success,
         rolls: roll.dice[0].rolls,
         difficultyGroup: dg,
         penaltySources: baseData.penaltySources,
@@ -82,9 +83,10 @@ async function skillRollCallback(
         fateReroll,
         callons
     };
-
-    await helpers.addTestToSkill(skill, dg);
-    skill = sheet.actor.getOwnedItem(skill._id) as Skill; // update skill with new data
+    if (success || sheet.actor.data.successOnlyRolls.indexOf(skill.name.toLowerCase()) === -1) {
+        await helpers.addTestToSkill(skill, dg);
+        skill = sheet.actor.getOwnedItem(skill._id) as Skill; // update skill with new data
+    }
     if (helpers.canAdvance(skill.data.data)) {
         Dialog.confirm({
             title: `Advance ${skill.name}?`,

--- a/module/templates.ts
+++ b/module/templates.ts
@@ -10,7 +10,8 @@ export async function preloadHandlebarsTemplates() {
       "systems/burningwheel/templates/parts/relationships.html",
       "systems/burningwheel/templates/parts/rollable-item.html",
       "systems/burningwheel/templates/parts/rollable-skill.html",
-      "systems/burningwheel/templates/parts/weapons.html"
+      "systems/burningwheel/templates/parts/weapons.html",
+      "systems/burningwheel/templates/parts/character-settings.html"
     ];
 
     // Load the template parts

--- a/styles/burningwheel.scss
+++ b/styles/burningwheel.scss
@@ -4,6 +4,7 @@
 @import "./character/learning.scss";
 @import "./character/ptgs.scss";
 @import "./character/relationships.scss";
+@import "./character/settings.scss";
 @import "./character/weapons.scss";
 @import "./chat/dialog.scss";
 @import "./chat/roll.scss";

--- a/styles/character/character.scss
+++ b/styles/character/character.scss
@@ -14,6 +14,20 @@
             margin-top: .75em;
             margin-bottom: 0px;
             background-color: rgba(0,0,0,0.05);
+
+            .settings-gear {
+                font-size: .75em;
+                float: right;
+                margin: 5px 5px 0 0;
+                color: grey;
+                &:hover {
+                    color: red;
+                }
+            }
+
+            .settings-checkbox:checked ~ .settings-gear {
+                color: black;
+            }
         }
 
         text-align: center;

--- a/styles/character/settings.scss
+++ b/styles/character/settings.scss
@@ -1,0 +1,46 @@
+.character-settings-section {
+    background-color: white;
+    border: 2px solid black;
+    border-radius: 10px;
+    padding: 10px;
+    margin-bottom: 10px;
+
+    .checkbox-grid {
+        grid-template-columns: repeat(auto-fill, 24px calc(33% - 24px));
+    }
+
+    .settings-items {
+        padding: 3px;
+        border: 2px inset black;
+        border-radius: 5px;
+        height: 15em;
+        overflow-y: scroll;
+        border-bottom: 2px inset grey;
+        border-right: 2px inset grey;
+        
+
+        .setting-item-header,
+        .setting-item-row {
+            display: grid;
+            grid-template-columns: 4fr 1fr 24px 24px;
+            margin-bottom: 3px;
+            i:hover {
+                color: red;
+            }
+        }
+
+        .setting-item-header {
+            background-color: rgba(black, .15);
+            font-weight: bold;
+            font-size: 1.5em;
+            border-bottom: 2px solid black;
+        }
+
+        .setting-item-row {
+            font-size: 1em;
+            &:nth-child(2n) {
+                background-color: rgba(black, .05);
+            }
+        }
+    }
+}

--- a/template.yml
+++ b/template.yml
@@ -83,11 +83,20 @@ Actor:
       fate: 0
       persona: 0
       deeds: 0
+    settings:
+      settings:
+        showSettings: false
+        roundUpMortalWound: false
+        roundUpReflexes: false
+        onlySuccessesCount: 'Faith, Resources, Perception'
+        armorTrained: false
+        ignoreSuperficialWounds: false
   character:
     templates:
       - common
       - displayProps
       - ptgs
+      - settings
     stock: ''
     age: 18
     lifepathString: ''

--- a/templates/character-sheet.html
+++ b/templates/character-sheet.html
@@ -1,10 +1,16 @@
 <form autocomplete="off" class="character">
+    {{#if data.settings.showSettings}}
+    {{> "systems/burningwheel/templates/parts/character-settings.html"}}
+    {{/if}}
     <div class="character-header flex-row">
         <div class="portrait">
             <img class="profile" src="{{actor.img}}" title="{{actor.name}}" data-edit="img"/>
         </div>
         <div class="section-index item-grid col-2">
-            <h2 class="section-header">Character Index</h2>
+            <h2 class="section-header">Character Index
+                <input id="{{actor._id}}-settings-checkbox" type="checkbox" class="hidden settings-checkbox" name="data.settings.showSettings" {{checked data.settings.showSettings}}>
+                <label class="settings-gear" for="{{actor._id}}-settings-checkbox"><i class="fas fa-cogs"></i></label>
+            </h2>
             <div>
                 <label for="character-name">Name</label>
                 <input id="character-name" type="text" name="name" value="{{actor.name}}">

--- a/templates/parts/character-settings.html
+++ b/templates/parts/character-settings.html
@@ -1,0 +1,36 @@
+<div class="character-settings-section">
+    <h2>Character Settings</h2>
+    <div class="checkbox-grid">
+        <input id="checkbox-{{actor._id}}-round-up-mw" type="checkbox" name="data.settings.roundUpMortalWound" {{checked data.settings.roundUpMortalWound}}>
+        <label for="checkbox-{{actor._id}}-round-up-mw">Round Up Mortal Wound</label>
+        <input id="checkbox-{{actor._id}}-round-up-reflex" type="checkbox" name="data.settings.roundUpReflexes" {{checked data.settings.roundUpReflexes}}>
+        <label for="checkbox-{{actor._id}}-round-up-reflex">Round Up Reflexes</label>
+        <input id="checkbox-{{actor._id}}-armor-trained" type="checkbox" name="data.settings.armorTrained" {{checked data.settings.armorTrained}}>
+        <label for="checkbox-{{actor._id}}-armor-trained">Armor Trained</label>
+        <input id="checkbox-{{actor._id}}-numb" type="checkbox" name="data.settings.ignoreSuperficialWounds" {{checked data.settings.ignoreSuperficialWounds}}>
+        <label for="checkbox-{{actor._id}}-numb">Ignore Superficial Wounds</label>
+    </div>
+    <hr>
+    <div>
+        <input id="input-{{actor._id}}-success-only" type="text" name="data.settings.onlySuccessesCount" value="{{data.settings.onlySuccessesCount}}" >
+        <label for="input-{{actor._id}}-success-only">Skills for which only successes count.</label>
+    </div>
+    <hr>
+    <h2>Embedded Items</h2>
+    <div class="settings-items flex-column">
+        <div class="setting-item-header">
+            <div>Name</div>
+            <div>Type</div>
+            <div>&nbsp;</div>
+            <div>&nbsp;</div>
+        </div>
+        {{#each actor.items as |i|}}
+        <div class="setting-item-row">
+            <div>{{i.name}}</div>
+            <div>{{titlecase i.type}}</div>
+            <div><i class="fas fa-edit" data-action="editItem" data-id="{{i._id}}"></i></div>
+            <div><i class="fas fa-trash" data-action="delItem" data-id="{{i._id}}"></i></div>
+        </div>
+        {{/each}}
+    </div>
+</div>


### PR DESCRIPTION
Add a settings section that may be rendered at the top of the character
sheet that can be used to modify the way that certain values are
calculated and to manually edit any existing items attached to a
character

Resolves #56 - Sheet settings section