### PR TITLE
Fix duplicate ID errors with the two custom stats

### DIFF
--- a/module/character-sheet.ts
+++ b/module/character-sheet.ts
@@ -174,7 +174,7 @@ export class BWCharacterSheet extends BWActorSheet {
         return this.actor.createOwnedItem({ name: "Instinct 1", type: "instinct", data: {}})
             .then(() => this.actor.createOwnedItem({ name: "Instinct 2", type: "instinct", data: {}}))
             .then(() => this.actor.createOwnedItem({ name: "Instinct 3", type: "instinct", data: {}}))
-            .then(() => this.actor.createOwnedItem({ name: "Instinct Speceial", type: "instinct", data: {}}))
+            .then(() => this.actor.createOwnedItem({ name: "Instinct Special", type: "instinct", data: {}}))
             .then(() => this.actor.createOwnedItem({ name: "Belief 1", type: "belief", data: {}}))
             .then(() => this.actor.createOwnedItem({ name: "Belief 2", type: "belief", data: {}}))
             .then(() => this.actor.createOwnedItem({ name: "Belief 3", type: "belief", data: {}}))

--- a/module/items/item.ts
+++ b/module/items/item.ts
@@ -8,6 +8,7 @@ import { Reputation } from "./reputation.js";
 import { AffiliationSheet } from "./sheets/affiliation-sheet.js";
 import { ArmorSheet } from "./sheets/armor-sheet.js";
 import { BeliefSheet } from "./sheets/belief-sheet.js";
+import { InstinctSheet } from "./sheets/instinct-sheet.js";
 import { MeleeWeaponSheet } from "./sheets/melee-sheet.js";
 import { PosessionSheet } from "./sheets/posession-sheet.js";
 import { PropertySheet } from "./sheets/property-sheet.js";
@@ -31,6 +32,7 @@ export * from "./reputation.js";
 export * from "./sheets/affiliation-sheet.js";
 export * from "./sheets/armor-sheet.js";
 export * from "./sheets/belief-sheet.js";
+export * from "./sheets/instinct-sheet.js";
 export * from "./sheets/melee-sheet.js";
 export * from "./sheets/posession-sheet.js";
 export * from "./sheets/property-sheet.js";
@@ -65,6 +67,10 @@ export function RegisterItemSheets() {
     Items.unregisterSheet("core", ItemSheet);
     Items.registerSheet("burningwheel", BeliefSheet, {
         types: ["belief"],
+        makeDefault: true
+    });
+    Items.registerSheet("burningwheel", InstinctSheet, {
+        types: ["instinct"],
         makeDefault: true
     });
     Items.registerSheet("burningwheel", TraitSheet, {

--- a/module/items/sheets/instinct-sheet.ts
+++ b/module/items/sheets/instinct-sheet.ts
@@ -1,0 +1,6 @@
+export class InstinctSheet extends ItemSheet {
+    getData() {
+        const data = super.getData();
+        return data;
+    }
+}

--- a/templates/character-sheet.html
+++ b/templates/character-sheet.html
@@ -293,7 +293,7 @@
     </label>
     <div class="learning-practice flex-row">
         <div class="flex-row learning-section">
-            {{#each leaning as |skill|}}
+            {{#each learning as |skill|}}
                 {{> "systems/burningwheel/templates/parts/learning.html" skill=skill }}
             {{/each}}
         </div>

--- a/templates/parts/rollable-item.html
+++ b/templates/parts/rollable-item.html
@@ -1,6 +1,6 @@
 <div class="rollable flex-row {{stat.cssClass}}">
-    <input id="{{actor._id}}-{{statName}}Toggle" class="collapse-checkbox" type="checkbox" name="{{namePrefix}}.collapsed" {{ checked stat.collapsed}}>
-    <label for="{{actor._id}}-{{statName}}Toggle" class="collapse-label"><i class="fas fa-chevron-circle-down"></i></label>
+    <input id="{{actor._id}}-{{namePrefix}}-Toggle" class="collapse-checkbox" type="checkbox" name="{{namePrefix}}.collapsed" {{ checked stat.collapsed}}>
+    <label for="{{actor._id}}-{{namePrefix}}-Toggle" class="collapse-label"><i class="fas fa-chevron-circle-down"></i></label>
     {{#if customName }}
     <input type="text" name="{{namePrefix}}.name" value="{{stat.name}}" class="rollable-name">
     {{else}}
@@ -21,16 +21,16 @@
             <div class="test-title">Routine: </div>
             <input class="tests-needed" name="{{namePrefix}}.routineNeeded" value="{{stat.routineNeeded}}" disabled>
             {{#multiboxes stat.routine needed=stat.routineNeeded}}
-            <input type="radio" id="{{actor._id}}-{{statName}}-routine-0" name="{{namePrefix}}.routine" value="0" checked="checked">
-            <label for="{{actor._id}}-{{statName}}-routine-0" class="progress-clear"><i class="fas fa-times-circle"></i></label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-routine-1" name="{{namePrefix}}.routine" value="1">
-            <label for="{{actor._id}}-{{statName}}-routine-1" class="progress-tick progress-tick-1">&nbsp;</label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-routine-2" name="{{namePrefix}}.routine" value="2">
-            <label for="{{actor._id}}-{{statName}}-routine-2" class="progress-tick progress-tick-2">&nbsp;</label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-routine-3" name="{{namePrefix}}.routine" value="3">
-            <label for="{{actor._id}}-{{statName}}-routine-3" class="progress-tick progress-tick-3">&nbsp;</label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-routine-4" name="{{namePrefix}}.routine" value="4">
-            <label for="{{actor._id}}-{{statName}}-routine-4" class="progress-tick progress-tick-4">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-routine-0" name="{{namePrefix}}.routine" value="0" checked="checked">
+            <label for="{{actor._id}}-{{namePrefix}}-routine-0" class="progress-clear"><i class="fas fa-times-circle"></i></label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-routine-1" name="{{namePrefix}}.routine" value="1">
+            <label for="{{actor._id}}-{{namePrefix}}-routine-1" class="progress-tick progress-tick-1">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-routine-2" name="{{namePrefix}}.routine" value="2">
+            <label for="{{actor._id}}-{{namePrefix}}-routine-2" class="progress-tick progress-tick-2">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-routine-3" name="{{namePrefix}}.routine" value="3">
+            <label for="{{actor._id}}-{{namePrefix}}-routine-3" class="progress-tick progress-tick-3">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-routine-4" name="{{namePrefix}}.routine" value="4">
+            <label for="{{actor._id}}-{{namePrefix}}-routine-4" class="progress-tick progress-tick-4">&nbsp;</label>
             {{/multiboxes}}
         </div>
         {{/if}}
@@ -38,30 +38,30 @@
             <div class="test-title">Difficult:</div>
             <input class="tests-needed" name="{{namePrefix}}.difficultNeeded" value="{{stat.difficultNeeded}}" disabled>
             {{#multiboxes stat.difficult needed=stat.difficultNeeded}}
-            <input type="radio" id="{{actor._id}}-{{statName}}-difficult-0" name="{{namePrefix}}.difficult" value="0" checked="checked">
-            <label for="{{actor._id}}-{{statName}}-difficult-0" class="progress-clear"><i class="fas fa-times-circle"></i></label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-difficult-1" name="{{namePrefix}}.difficult" value="1">
-            <label for="{{actor._id}}-{{statName}}-difficult-1" class="progress-tick progress-tick-1">&nbsp;</label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-difficult-2" name="{{namePrefix}}.difficult" value="2">
-            <label for="{{actor._id}}-{{statName}}-difficult-2" class="progress-tick progress-tick-2">&nbsp;</label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-difficult-3" name="{{namePrefix}}.difficult" value="3">
-            <label for="{{actor._id}}-{{statName}}-difficult-3" class="progress-tick progress-tick-3">&nbsp;</label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-difficult-4" name="{{namePrefix}}.difficult" value="4">
-            <label for="{{actor._id}}-{{statName}}-difficult-4" class="progress-tick progress-tick-4">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-difficult-0" name="{{namePrefix}}.difficult" value="0" checked="checked">
+            <label for="{{actor._id}}-{{namePrefix}}-difficult-0" class="progress-clear"><i class="fas fa-times-circle"></i></label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-difficult-1" name="{{namePrefix}}.difficult" value="1">
+            <label for="{{actor._id}}-{{namePrefix}}-difficult-1" class="progress-tick progress-tick-1">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-difficult-2" name="{{namePrefix}}.difficult" value="2">
+            <label for="{{actor._id}}-{{namePrefix}}-difficult-2" class="progress-tick progress-tick-2">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-difficult-3" name="{{namePrefix}}.difficult" value="3">
+            <label for="{{actor._id}}-{{namePrefix}}-difficult-3" class="progress-tick progress-tick-3">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-difficult-4" name="{{namePrefix}}.difficult" value="4">
+            <label for="{{actor._id}}-{{namePrefix}}-difficult-4" class="progress-tick progress-tick-4">&nbsp;</label>
             {{/multiboxes}}
         </div>
         <div class="test-tracking">
             <div class="test-title">Challenging:</div>
             <input class="tests-needed" name="{{namePrefix}}.challengingNeeded" value="{{stat.challengingNeeded}}" disabled>
             {{#multiboxes stat.challenging needed=stat.challengingNeeded}}
-            <input type="radio" id="{{actor._id}}-{{statName}}-challenging-0" name="{{namePrefix}}.challenging" value="0" checked="checked">
-            <label for="{{actor._id}}-{{statName}}-challenging-0" class="progress-clear"><i class="fas fa-times-circle"></i></label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-challenging-1" name="{{namePrefix}}.challenging" value="1">
-            <label for="{{actor._id}}-{{statName}}-challenging-1" class="progress-tick progress-tick-1">&nbsp;</label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-challenging-2" name="{{namePrefix}}.challenging" value="2">
-            <label for="{{actor._id}}-{{statName}}-challenging-2" class="progress-tick progress-tick-2">&nbsp;</label>
-            <input type="radio" id="{{actor._id}}-{{statName}}-challenging-3" name="{{namePrefix}}.challenging" value="3">
-            <label for="{{actor._id}}-{{statName}}-challenging-3" class="progress-tick progress-tick-3">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-challenging-0" name="{{namePrefix}}.challenging" value="0" checked="checked">
+            <label for="{{actor._id}}-{{namePrefix}}-challenging-0" class="progress-clear"><i class="fas fa-times-circle"></i></label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-challenging-1" name="{{namePrefix}}.challenging" value="1">
+            <label for="{{actor._id}}-{{namePrefix}}-challenging-1" class="progress-tick progress-tick-1">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-challenging-2" name="{{namePrefix}}.challenging" value="2">
+            <label for="{{actor._id}}-{{namePrefix}}-challenging-2" class="progress-tick progress-tick-2">&nbsp;</label>
+            <input type="radio" id="{{actor._id}}-{{namePrefix}}-challenging-3" name="{{namePrefix}}.challenging" value="3">
+            <label for="{{actor._id}}-{{namePrefix}}-challenging-3" class="progress-tick progress-tick-3">&nbsp;</label>
             {{/multiboxes}}
         </div>
         <input type="number" class="circle-input" placeholder="F" title="Fate points spent on {{statName}}" name="{{namePrefix}}.fate" value="{{stat.fate}}">
@@ -73,9 +73,9 @@
             <input type="number" class="circle-input" name="{{taxName}}" value="{{taxValue}}">
         </div>
         {{/if}}
-        <input type="checkbox" class="hidden rollable-open-checkbox" id="{{actor._id}}-{{statName}}-open" name="{{namePrefix}}.open" {{checked stat.open}}>
+        <input type="checkbox" class="hidden rollable-open-checkbox" id="{{actor._id}}-{{namePrefix}}-open" name="{{namePrefix}}.open" {{checked stat.open}}>
         <div class="rollable-open-toggle">
-            <label for="{{actor._id}}-{{statName}}-open">Open</label>
+            <label for="{{actor._id}}-{{namePrefix}}-open">Open</label>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixed an issue where custom1 and custom2 attribute labels were causing
duplicate ID issues with inputs when both were equal.

Fixed a few typos minor bugs
Resolves #31