### PR TITLE
Fix Duplicate fist weapon being added to a character sheet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
     steps:
       - checkout
       - node/with-cache:
+          cache-version: v2
           steps:
             - run: npm install
             - run: sudo npm install -g gulp

--- a/module/burningwheel.ts
+++ b/module/burningwheel.ts
@@ -14,7 +14,7 @@ import { preloadHandlebarsTemplates } from "./templates.js";
 Hooks.once("init", async () => {
     CONFIG.Actor.entityClass = BWActor;
     CONFIG.Item.entityClass = BWItem;
-    (game as any).burningwheel = {};
+    game.burningwheel = {};
 
     Actors.unregisterSheet("core", ActorSheet);
     Actors.registerSheet("burningwheel", BWCharacterSheet, {

--- a/module/burningwheel.ts
+++ b/module/burningwheel.ts
@@ -7,6 +7,8 @@ import {
 
 import { hideChatButtonsIfNotOwner, onChatLogRender } from "./chat.js";
 import { slugify } from "./helpers.js";
+import { migrateData } from "./migration.js";
+import { registerSystemSettings } from "./settings.js";
 import { preloadHandlebarsTemplates } from "./templates.js";
 
 Hooks.once("init", async () => {
@@ -21,8 +23,13 @@ Hooks.once("init", async () => {
     });
     RegisterItemSheets();
 
+    registerSystemSettings();
     preloadHandlebarsTemplates();
     registerHelpers();
+});
+
+Hooks.once("ready", async() => {
+    migrateData();
 });
 
 function registerHelpers() {

--- a/module/character-sheet.ts
+++ b/module/character-sheet.ts
@@ -153,7 +153,7 @@ export class BWCharacterSheet extends BWActorSheet {
                 .sort((a, b) => a.name < b.name ? -1 : (a.name === b.name ? 0 : 1));
 
             // cache the current list of skills since it'll be used after for the actual skill data
-            (game as any).burningwheel.skills = skills;
+            game.burningwheel.skills = skills;
             console.log(skills);
             const html = await renderTemplate("systems/burningwheel/templates/chat/new-skill-dialog.html", { skills });
             const dialog = new Dialog({
@@ -166,7 +166,7 @@ export class BWCharacterSheet extends BWActorSheet {
                             const skillData: SkillDataRoot[] = [];
                             dialogHtml.find('input:checked')
                                 .each((_, element: HTMLInputElement) => {
-                                    const skillRoot: SkillDataRoot = (game as any).burningwheel.skills
+                                    const skillRoot: SkillDataRoot = game.burningwheel.skills
                                         .find((s: Skill) => s._id === element.value).data;
                                     skillRoot.data.learning = true;
                                     skillData.push(skillRoot);

--- a/module/character-sheet.ts
+++ b/module/character-sheet.ts
@@ -16,7 +16,7 @@ import {
     Trait,
     TraitDataRoot,
 } from "./items/item.js";
-import { handleRollable } from "./rolls.js";
+import { handleRollable } from "./rolls/rolls.js";
 
 export class BWCharacterSheet extends BWActorSheet {
     getData(): CharacterSheetData {
@@ -71,15 +71,7 @@ export class BWCharacterSheet extends BWActorSheet {
             }
         }
 
-        if (beliefs.length === 0 && instincts.length === 0) {
-            console.log("adding default beliefs");
-            this.addDefaultItems();
-        }
-
-        if (addFist) {
-            // we need to add the default fist weapon to weapons list
-            this.actor.createOwnedItem(constants.bareFistData).then(i => data.melee.push(i as MeleeWeapon));
-        }
+        this._maybeInitializeActor();
 
         data.beliefs = beliefs;
         data.instincts = instincts;
@@ -108,6 +100,16 @@ export class BWCharacterSheet extends BWActorSheet {
         data.traits = traitLists;
         data.systemVersion = game.system.data.version;
         return data;
+    }
+
+    async _maybeInitializeActor() {
+        const initialized = await this.actor.getFlag("burningwheel", "initialized") as boolean;
+        if (initialized) {
+            return;
+        }
+        await this.actor.setFlag("burningwheel", "initialized", true);
+        await this.addDefaultItems();
+        return this.actor.createOwnedItem(constants.bareFistData);
     }
 
     getArmorDictionary(armorItems: Item[]): { [key: string]: Item | null; } {

--- a/module/migration.ts
+++ b/module/migration.ts
@@ -1,0 +1,21 @@
+export async function migrateData() {
+    const latest = game.system.data.version;
+    const recentVersion = await game.settings.get("burningwheel", "version") || "0.0.0";
+    await game.settings.set("burningwheel", "version", latest);
+
+    if (isNewerVersion(latest, recentVersion)) {
+        // we need to do some updates.
+        if (isNewerVersion("0.2.1", recentVersion)) {
+            // refactored intiatilization code to use a flag for actors
+            // to initialize fists, beliefs and instincts on new characters
+            // only if a flag was set.
+            // these items will have already been initialized on existing
+            // characters so avoid re-initalizing them by setting the flag to true.
+            const actors: Actor[] = Array.from(game.actors.values());
+            for (const actor of actors) {
+                await actor.setFlag("burningwheel", "initialized", true);
+            }
+            ui.notifications.notify(`Your data has been updated to version 0.2.1 from ${recentVersion}`, 'info');
+        }
+    }
+}

--- a/module/rolls/rerollCallon.ts
+++ b/module/rolls/rerollCallon.ts
@@ -2,7 +2,7 @@ import { TestString } from "module/helpers.js";
 import { Ability, BWActor, TracksTests } from "../actor.js";
 import * as helpers from "../helpers.js";
 import { Skill, SkillData } from "../items/item.js";
-import { rollDice, templates } from "../rolls.js";
+import { rollDice, templates } from "./rolls.js";
 
 export async function handleCallonReroll(target: HTMLButtonElement): Promise<unknown> {
     const actor = game.actors.get(target.dataset.actorId || "") as BWActor;

--- a/module/rolls/rerollFate.ts
+++ b/module/rolls/rerollFate.ts
@@ -2,7 +2,7 @@ import { TestString } from "module/helpers.js";
 import { Ability, BWActor, TracksTests } from "../actor.js";
 import * as helpers from "../helpers.js";
 import { Skill, SkillData } from "../items/item.js";
-import { RerollMessageData, rollDice, templates } from "../rolls.js";
+import { RerollMessageData, rollDice, templates } from "./rolls.js";
 
 export async function handleFateReroll(target: HTMLButtonElement): Promise<unknown> {
     const actor = game.actors.get(target.dataset.actorId || "") as BWActor;

--- a/module/rolls/rollAttribute.ts
+++ b/module/rolls/rollAttribute.ts
@@ -11,7 +11,7 @@ import {
     RollChatMessageData,
     rollDice,
     templates
-} from "../rolls.js";
+} from "./rolls.js";
 
 export async function handleAttrRoll(target: HTMLButtonElement, sheet: BWActorSheet): Promise<unknown> {
     const stat = getProperty(sheet.actor.data, target.dataset.accessor || "") as Ability;

--- a/module/rolls/rollCircles.ts
+++ b/module/rolls/rollCircles.ts
@@ -12,7 +12,7 @@ import {
     RollChatMessageData,
     rollDice,
     templates
-} from "../rolls.js";
+} from "./rolls.js";
 
 export async function handleCirclesRoll(target: HTMLButtonElement, sheet: BWActorSheet): Promise<unknown> {
     const stat = getProperty(sheet.actor.data, "data.circles") as Ability;

--- a/module/rolls/rollLearning.ts
+++ b/module/rolls/rollLearning.ts
@@ -13,7 +13,7 @@ import {
     RollChatMessageData,
     rollDice,
     templates
-} from "../rolls.js";
+} from "./rolls.js";
 
 export async function handleLearningRoll(target: HTMLButtonElement, sheet: BWActorSheet): Promise<unknown> {
     const skillId = target.dataset.skillId || "";

--- a/module/rolls/rollPtgs.ts
+++ b/module/rolls/rollPtgs.ts
@@ -11,7 +11,7 @@ import {
     RollChatMessageData,
     rollDice,
     templates
-} from "../rolls.js";
+} from "./rolls.js";
 
 export async function handleShrugRoll(target: HTMLButtonElement, sheet: BWActorSheet): Promise<unknown> {
     return handlePtgsRoll(target, sheet, true);

--- a/module/rolls/rollResources.ts
+++ b/module/rolls/rollResources.ts
@@ -12,7 +12,7 @@ import {
     RollChatMessageData,
     rollDice,
     templates,
-} from "../rolls.js";
+} from "./rolls.js";
 
 export async function handleResourcesRoll(_target: HTMLButtonElement, sheet: BWActorSheet): Promise<unknown> {
     const stat = sheet.actor.data.data.resources;

--- a/module/rolls/rollSkill.ts
+++ b/module/rolls/rollSkill.ts
@@ -13,7 +13,7 @@ import {
     RollDialogData,
     rollDice,
     templates
-} from "../rolls.js";
+} from "./rolls.js";
 
 export async function handleSkillRoll(target: HTMLButtonElement, sheet: BWActorSheet): Promise<unknown> {
     const skillId = target.dataset.skillId || "";

--- a/module/rolls/rollStat.ts
+++ b/module/rolls/rollStat.ts
@@ -11,7 +11,7 @@ import {
     RollDialogData,
     rollDice,
     templates
-} from "../rolls.js";
+} from "./rolls.js";
 
 export async function handleStatRoll(target: HTMLButtonElement, sheet: BWActorSheet): Promise<unknown> {
     const stat = getProperty(sheet.actor.data, target.dataset.accessor || "") as Ability;

--- a/module/rolls/rolls.ts
+++ b/module/rolls/rolls.ts
@@ -153,8 +153,8 @@ export async function rollDice(numDice: number, open: boolean = false, shade: he
     } else {
         const tgt = shade === 'B' ? '3' : (shade === 'G' ? '2' : '1');
         const roll = new Roll(`${numDice}d6${open?'x':''}cs>${tgt}`).roll();
-        if ((game as any).dice3d) {
-            return (game as any).dice3d.showForRoll(roll, game.user, true, null, false)
+        if (game.dice3d) {
+            return game.dice3d.showForRoll(roll, game.user, true, null, false)
                 .then(_ => helpers.sleep(1000))
                 .then(_ => roll);
         }

--- a/module/rolls/rolls.ts
+++ b/module/rolls/rolls.ts
@@ -1,14 +1,14 @@
-import { Ability, BWActor, RollModifier, TracksTests } from "./actor.js";
-import { BWActorSheet } from "./bwactor-sheet.js";
-import * as helpers from "./helpers.js";
-import { Skill, SkillDataRoot } from "./items/item.js";
-import { handleAttrRoll } from "./rolls/rollAttribute.js";
-import { handleCirclesRoll } from "./rolls/rollCircles.js";
-import { handleLearningRoll } from "./rolls/rollLearning.js";
-import { handleGritRoll, handleShrugRoll } from "./rolls/rollPtgs.js";
-import { handleResourcesRoll } from "./rolls/rollResources.js";
-import { handleSkillRoll } from "./rolls/rollSkill.js";
-import { handleStatRoll } from "./rolls/rollStat.js";
+import { Ability, BWActor, RollModifier, TracksTests } from "../actor.js";
+import { BWActorSheet } from "../bwactor-sheet.js";
+import * as helpers from "../helpers.js";
+import { Skill, SkillDataRoot } from "../items/item.js";
+import { handleAttrRoll } from "./rollAttribute.js";
+import { handleCirclesRoll } from "./rollCircles.js";
+import { handleLearningRoll } from "./rollLearning.js";
+import { handleGritRoll, handleShrugRoll } from "./rollPtgs.js";
+import { handleResourcesRoll } from "./rollResources.js";
+import { handleSkillRoll } from "./rollSkill.js";
+import { handleStatRoll } from "./rollStat.js";
 
 export async function handleRollable(
     e: JQuery.ClickEvent<HTMLElement, null, HTMLElement, HTMLElement>, sheet: BWActorSheet): Promise<unknown> {

--- a/module/settings.ts
+++ b/module/settings.ts
@@ -1,0 +1,9 @@
+export function registerSystemSettings() {
+    game.settings.register("burningwheel", "version", {
+        name: "Current World Version",
+        scope: "world",
+        config: false,
+        type: String,
+        default: "0.0.0"
+      });
+}


### PR DESCRIPTION
Adds logic to character initialization that only adds initial items like fists and beliefs one time.
Adds code path for version based data migration.

Resolves #41 