### PR TITLE
Toolkit Penalty

### DIFF
--- a/module/actor.ts
+++ b/module/actor.ts
@@ -1,5 +1,5 @@
 import { canAdvance, ShadeString, TestString, updateTestsNeeded, StringIndexedObject } from "./helpers.js";
-import { ArmorRootData, DisplayClass, ItemType, Trait, TraitDataRoot, ReputationDataRoot, BWItemData } from "./items/item.js";
+import { ArmorRootData, DisplayClass, ItemType, Trait, TraitDataRoot, ReputationDataRoot, BWItemData, PossessionRootData } from "./items/item.js";
 import { SkillDataRoot } from "./items/skill.js";
 
 export class BWActor extends Actor {
@@ -304,6 +304,7 @@ export class BWActor extends Actor {
         this.data.circlesMalus = [];
         this.data.martialSkills = [];
         this.data.sorcerousSkills = [];
+        this.data.toolkits = [];
         if (this.data.items) {
             this.data.items.forEach((i) => {
                 switch (i.type) {
@@ -352,6 +353,10 @@ export class BWActor extends Actor {
                             }
                         }
                         break;
+                    case "possession":
+                        if ((i as PossessionRootData).data.isToolkit) {
+                            this.data.toolkits.push(i);
+                        }
                 }
             });
         }
@@ -446,8 +451,8 @@ export class BWActor extends Actor {
             }
 
 
-            if ((a.data.hasHelm || a.data.hasLeftArm || a.data.hasRightArm || a.data.hasTorso
-                || a.data.hasLeftLeg || a.data.hasRightLeg ) && !this.data.data.settings.armorTrained) {
+            if (!this.data.data.settings.armorTrained &&
+                (a.data.hasHelm || a.data.hasLeftArm || a.data.hasRightArm || a.data.hasTorso || a.data.hasLeftLeg || a.data.hasRightLeg)) {
                 // if this is more than just a shield
                 if (a.data.untrainedPenalty === "plate") {
                     clumsyWeight.untrainedAll = Math.max(clumsyWeight.untrainedAll, 2);
@@ -494,9 +499,11 @@ export class BWActor extends Actor {
 }
 
 export interface CharacterDataRoot extends ActorData<BWCharacterData> {
+    toolkits: PossessionRootData[];
     martialSkills: SkillDataRoot[];
     sorcerousSkills: SkillDataRoot[];
     wildForks: SkillDataRoot[];
+
     circlesMalus: { name: string, amount: number }[];
     circlesBonus: { name: string, amount: number }[];
     data: BWCharacterData;

--- a/module/items/skill.ts
+++ b/module/items/skill.ts
@@ -49,6 +49,8 @@ export interface SkillData extends TracksTests, DisplayClass {
     learning: boolean;
     learningProgress: string;
 
+    tools: boolean;
+
     routineNeeded?: number;
     difficultNeeded?: number;
     challengingNeeded?: number;

--- a/module/rolls/rolls.ts
+++ b/module/rolls/rolls.ts
@@ -1,7 +1,7 @@
 import { Ability, BWActor, RollModifier, TracksTests } from "../actor.js";
 import { BWActorSheet } from "../bwactor-sheet.js";
 import * as helpers from "../helpers.js";
-import { Skill, SkillDataRoot } from "../items/item.js";
+import { Skill, SkillDataRoot, Possession } from "../items/item.js";
 import { handleAttrRoll } from "./rollAttribute.js";
 import { handleCirclesRoll } from "./rollCircles.js";
 import { handleLearningRoll } from "./rollLearning.js";
@@ -224,6 +224,18 @@ export function getRollNameClass(open: boolean, shade: helpers.ShadeString): str
 export async function getNoDiceErrorDialog(numDice: number): Promise<Application> {
     return helpers.notifyError("Too Few Dice",
         `Too few dice to be rolled. Must roll a minimum of one. Currently, bonuses and penalties add up to ${numDice}`);
+}
+
+export async function maybeExpendTools(tools: Possession): Promise<unknown> {
+    const roll = await rollDice(1, false, "B");
+    if (roll && roll.dice[0].rolls[0].roll === 1) {
+        return Dialog.confirm({
+            title: "Expend toolkit",
+            content: `<p>The die of fate result was a 1 and thus the toolkit used (${tools.name}) is expended.</p><hr><p>Update the toolkit?</p>`,
+            yes: () => { tools.update({"data.isExpended": true}, null); },
+            no: () => { return; }
+        });
+    }
 }
 
 /* ============ Constants =============== */

--- a/module/rolls/rolls.ts
+++ b/module/rolls/rolls.ts
@@ -1,7 +1,7 @@
 import { Ability, BWActor, RollModifier, TracksTests } from "../actor.js";
 import { BWActorSheet } from "../bwactor-sheet.js";
 import * as helpers from "../helpers.js";
-import { Skill, SkillDataRoot, Possession } from "../items/item.js";
+import { Skill, Possession } from "../items/item.js";
 import { handleAttrRoll } from "./rollAttribute.js";
 import { handleCirclesRoll } from "./rollCircles.js";
 import { handleLearningRoll } from "./rollLearning.js";
@@ -257,10 +257,6 @@ export const templates = {
 
 
 /* =============== Types ================= */
-export interface LearningDialogData extends RollDialogData {
-    skill: SkillDataRoot;
-}
-
 export interface AttributeDialogData extends RollDialogData {
     stat: TracksTests;
     tax?: number;

--- a/styles/burningwheel.scss
+++ b/styles/burningwheel.scss
@@ -8,6 +8,7 @@
 @import "./character/weapons.scss";
 @import "./chat/dialog.scss";
 @import "./chat/roll.scss";
+@import "./items/item.scss";
 @import "./items/armor.scss";
 @import "./items/relationship.scss";
 @import "./items/spell.scss";

--- a/styles/items/item.scss
+++ b/styles/items/item.scss
@@ -1,0 +1,9 @@
+input.item-sheet-name {
+    border: 0;
+    border-radius: 0;
+    font-size: 2em;
+    font-weight: bolder;
+    height: 1.25em;
+    border-bottom: 2px groove lightpink;
+    margin-bottom: .5em;
+}

--- a/styles/items/skill.scss
+++ b/styles/items/skill.scss
@@ -1,26 +1,22 @@
+@import "../mixins.scss";
 .skill-form {
     .skill-form-group {
         display: grid;
-        grid-template-columns: repeat(4, min-content);
-        column-gap: 1em;
-        text-align: right;
-        margin-top: 5px;
-        font-size: 1em;
-        line-height: 1em;
-        
-        label {
-            white-space: nowrap;
-            display: inline-block;
-            margin-left: 10px;
-            vertical-align: middle;
-            line-height: 1.75em;
-            width: min-content;
-        }
+        grid-template-columns: repeat(4, 1fr);
+        column-gap: 5px;
+        row-gap: 5px;
+        margin-bottom: 5px;
         width: 100%;
 
-        &.half-width {
-            width: 50%;
-            grid-template-columns: repeat(2, min-content);
+        .skill-setting-label {
+            font-weight: bold;
+        }
+
+        .skill-setting-toggle {
+            @include button-like(grey)
+        }
+        .skill-setting-checkbox:checked + .skill-setting-toggle {
+            @include button-like-active;
         }
     }
 }

--- a/styles/items/spell.scss
+++ b/styles/items/spell.scss
@@ -12,15 +12,6 @@
         }
     }
 
-    .item-sheet-name {
-        border: 0;
-        border-radius: 0;
-        font-size: 2em;
-        font-weight: bolder;
-        height: 1.25em;
-        border-bottom: 2px groove lightpink;
-        margin-bottom: .5em;
-    }
     .spell-toggle-label {
         @include button-like(grey);
     }

--- a/template.yml
+++ b/template.yml
@@ -181,6 +181,7 @@ Item:
     deeds: 0
     open: false
     wildFork: false
+    tools: false
   relationship:
     description: ''
     forbidden: false

--- a/templates/character-sheet.html
+++ b/templates/character-sheet.html
@@ -286,7 +286,7 @@
 
     <input type="checkbox" id="{{actor._id}}-collapseMisc" name="data.collapseMisc" class="section-collapse misc-collapse" {{ checked data.collapseMisc }}>
     <label for="{{actor._id}}-collapseMisc" class="section-collapse-label">
-        <h2 class="section-header"><i class="fas fa-chevron-down"></i>Notes, Spells and Other Miscellanea</h2>
+        <h2 class="section-header"><i class="fas fa-chevron-down"></i>Notes and Other Miscellanea</h2>
     </label>
     <div class="misc-section item-grid col-3">
         <textarea name="data.miscNotes1" class="note-box" rows="4">{{data.miscNotes1}}</textarea>

--- a/templates/chat/roll-dialog.html
+++ b/templates/chat/roll-dialog.html
@@ -51,7 +51,7 @@
         </div>
         <div class="flex-row">
             <label for="select-toolkit" name="toolkit">Expend Toolkit?</label>
-            <select id="select-toolkit">
+            <select id="select-toolkit" name="toolkitId">
                 <option value="">None</option>
                 {{#each toolkits as |t|}}
                 <option value="{{t._id}}">{{t.name}}{{#if t.data.isExpended}} (Expended){{/if}}</option>

--- a/templates/chat/roll-dialog.html
+++ b/templates/chat/roll-dialog.html
@@ -41,6 +41,25 @@
             <input type="number" class="exponent" name="arthaDice" value="{{arthaDice}}">
         </div>
     </div>
+    {{#if needsToolkit}}
+    <hr>
+    <h2>Tools</h2>
+    <div class="item-grid col-2">
+        <div class="checkbox-grid">
+            <input id="checkbox-tool-penalty" type="checkbox" name="toolPenalty" value="1">
+            <label for="checkbox-tool-penalty">No Tools Penalty</label>
+        </div>
+        <div class="flex-row">
+            <label for="select-toolkit" name="toolkit">Expend Toolkit?</label>
+            <select id="select-toolkit">
+                <option value="">None</option>
+                {{#each toolkits as |t|}}
+                <option value="{{t._id}}">{{t.name}}{{#if t.data.isExpended}} (Expended){{/if}}</option>
+                {{/each}}
+            </select>
+        </div>
+    </div>
+    {{/if}}
     {{#if optionalDiceModifiers}}
     <hr>
     <h2>Other Dice Modifiers</h2>

--- a/templates/chat/skill-dialog.html
+++ b/templates/chat/skill-dialog.html
@@ -40,6 +40,25 @@
         {{/each}}
     </div>
     {{/if}}
+    {{#if needsToolkit}}
+    <hr>
+    <h2>Tools</h2>
+    <div class="item-grid col-2">
+        <div class="checkbox-grid">
+            <input id="checkbox-tool-penalty" type="checkbox" name="toolPenalty" value="1">
+            <label for="checkbox-tool-penalty">No Tools Penalty</label>
+        </div>
+        <div class="flex-row">
+            <label for="select-toolkit" name="toolkit">Expend Toolkit?</label>
+            <select id="select-toolkit" name="toolkitId">
+                <option value="">None</option>
+                {{#each toolkits as |t|}}
+                <option value="{{t._id}}">{{t.name}}{{#if t.data.isExpended}} (Expended){{/if}}</option>
+                {{/each}}
+            </select>
+        </div>
+    </div>
+    {{/if}}
     {{#if wildForks}}
     <hr>
     <h2>Wild FoRKs</h2>

--- a/templates/items/skill.html
+++ b/templates/items/skill.html
@@ -1,8 +1,8 @@
 <form autocomplete="off" class="skill-form flex-row">
-    <input name="name" type="text" value="{{item.name}}">
+    <input name="name" type="text" value="{{item.name}}" class="item-sheet-name">
     <hr>
     <div class="skill-form-group">
-        <label>
+        <label class="skill-setting-label">
             Skill Type
         </label>
         <select name="data.skilltype" value={{data.skilltype}} >
@@ -14,7 +14,7 @@
         </select>
     </div>
     <div class="skill-form-group">
-        <label>Root 1</label>
+        <label class="skill-setting-label">Root 1</label>
         <select name="data.root1" value={{data.root1}} >
             {{#select data.root1}}
             {{#each skillRoots as |root r|}}
@@ -22,7 +22,7 @@
             {{/each}}
             {{/select}}
         </select>
-        <label>Root 2 (Optional)</label>
+        <label class="skill-setting-label">Root 2 (Optional)</label>
         <select name="data.root2" value={{data.root2}} >
             {{#select data.root2}}
             <option value="">None</option>
@@ -33,19 +33,19 @@
         </select>
         <hr>
     </div>
-    <div class="skill-form-group half-width">
-        <label>Learning</label>
-        <input type="checkbox" name="data.learning" {{ checked data.learning }}>
-        <label>Aptitude</label>
-        <input type="number" name="data.aptitude" class="exponent" disabled value={{data.aptitude}}>
-        <label title="This skill explodes on 1's and 6's when used as a fork.">Wild Fork</label>
-        <input type="checkbox" name="data.wildFork" {{ checked data.wildFork }}>
-    </div>
-    <div class="skill-form-group half-width">
-        <label>Open</label>
-        <input type="checkbox" name="data.open" {{ checked data.open }}>
-        <label>Training Skill</label>
-        <input type="checkbox" name="data.training" {{ checked data.training }}>
+    <div class="skill-form-group">
+        <input id="{{item._id}}-learning" class="skill-setting-checkbox hidden" type="checkbox" name="data.learning" {{ checked data.learning }}>
+        <label for="{{item._id}}-learning" class="skill-setting-toggle">Learning</label>
+        <input id="{{item._id}}-aptitude" class="skill-setting-checkbox hidden" type="number" name="data.aptitude" class="exponent" disabled value={{data.aptitude}}>
+        <label for="{{item._id}}-aptitude" class="skill-setting-toggle">Aptitude</label>
+        <input id="{{item._id}}-wild" class="skill-setting-checkbox hidden" type="checkbox" name="data.wildFork" {{ checked data.wildFork }}>
+        <label for="{{item._id}}-wild" class="skill-setting-toggle" title="This skill explodes on 1's and 6's when used as a fork.">Wild Fork</label>
+        <input id="{{item._id}}-open-skill" class="skill-setting-checkbox hidden" type="checkbox" name="data.open" {{ checked data.open }}>
+        <label for="{{item._id}}-open-skill" class="skill-setting-toggle">Open</label>
+        <input id="{{item._id}}-training" class="skill-setting-checkbox hidden" type="checkbox" name="data.training" {{ checked data.training }}>
+        <label for="{{item._id}}-training" class="skill-setting-toggle">Training Skill</label>
+        <input id="{{item._id}}-tools" class="skill-setting-checkbox hidden" type="checkbox" name="data.tools" {{ checked data.tools }}>
+        <label for="{{item._id}}-tools" class="skill-setting-toggle">Requires Tools</label>
     </div>
     <textarea name="data.description">{{data.description}}</textarea>
 </form>


### PR DESCRIPTION
Adds toolkit use flag to items.
Adds logic for applying the missing toolkit doubling penalty.
Adds logic for automatically rolling to expend an item marked as a toolkit.

Also refactors skill item sheet

Resolves #50