### PR TITLE
Fix issue with skill roots and shade

### DIFF
--- a/module/helpers.ts
+++ b/module/helpers.ts
@@ -95,6 +95,15 @@ export function difficultyGroup(dice: number, difficulty: number): TestString {
      return (dice - spread >= difficulty) ? "Routine" : "Difficult";
 }
 
+export function getWorstShadeString(a: ShadeString, b: ShadeString): ShadeString {
+    if (a === b) {
+        return a;
+    } else if (a === "B" || b === "B") {
+        return "B";
+    }
+    return "G";
+}
+
 export function getArmorLocationDataFromItem(i: ArmorRootData): { [k: string]: ArmorRootData | null } {
     const data: StringIndexedObject<ArmorRootData | null> = {};
     data.head = i.data.hasHelm ? i : null;

--- a/module/rolls/rollLearning.ts
+++ b/module/rolls/rollLearning.ts
@@ -209,16 +209,30 @@ async function advanceLearningProgress(
         fr: RerollData | undefined,
         cb: (fr?: RerollData) => Promise<Entity>) {
     const progress = parseInt(skill.data.data.learningProgress, 10);
-    const requiredTests = skill.data.data.aptitude || 10;
+    let requiredTests = skill.data.data.aptitude || 10;
+    let shade = getProperty(skill.actor || {}, `data.data.${skill.data.data.root1.toLowerCase()}`).shade;
 
     skill.update({"data.learningProgress": progress + 1 }, {});
     if (progress + 1 >= requiredTests) {
+        if (skill.data.data.root2 && skill.actor) {
+            const root2Shade = getProperty(skill.actor, `data.data.${skill.data.data.root2.toLowerCase()}`).shade;
+            if (shade != root2Shade) {
+                requiredTests -= 2;
+            }
+            shade = helpers.getWorstShadeString(shade, root2Shade);
+        }
+
         Dialog.confirm({
             title: `Finish Training ${skill.name}?`,
             content: `<p>${skill.name} is ready to become a full skill. Go ahead?</p>`,
             yes: () => {
                 const updateData = {};
                 updateData["data.learning"] = false;
+                updateData["data.learningProgress"] = 0;
+                updateData["data.routine"] = 0;
+                updateData["data.difficult"] = 0;
+                updateData["data.challenging"] = 0;
+                updateData["data.shade"] = shade;
                 updateData["data.exp"] = Math.floor((10 - requiredTests) / 2);
                 skill.update(updateData, {});
             },

--- a/module/rolls/rolls.ts
+++ b/module/rolls/rolls.ts
@@ -193,14 +193,7 @@ export function getRootStatInfo(skill: Skill, actor: BWActor): { open: boolean, 
     const root2 = skill.data.data.root2 ?
         getProperty(actor, `data.data.${skill.data.data.root2}`) as Ability : root1;
 
-    let shade: helpers.ShadeString;
-    if (root1.shade === root2.shade) {
-        shade = root1.shade;
-    } else if (root1.shade === "B" || root2.shade === "B") {
-        shade = "B";
-    } else {
-        shade = "G";
-    }
+    const shade = helpers.getWorstShadeString(root1.shade, root2.shade);
     return {
         open: root1.open && root2.open,
         shade


### PR DESCRIPTION
- Fixed an issue where shade mismatch was not factoring into roots for
newly opened skills correctly.
- Fixed an issue where newly opened skill were not taking on the correct
shade of their parent skills

Resolves #62