### PR TITLE
Update Checkbox Toggle styles

### DIFF
--- a/styles/burningwheel.scss
+++ b/styles/burningwheel.scss
@@ -17,6 +17,7 @@
 @import "./items/skill.scss";
 @import "./items/trait.scss";
 @import "./npc/npc.scss";
+@import "./mixins.scss";
 
 .subheader,
 .header {
@@ -35,6 +36,10 @@ button.rollable {
 input.exponent {
     width: 2.5em;
     max-height: 28px;
+
+    &.no-arrows {
+        @include no-number-arrows;
+    }
 }
 
 input.hidden {
@@ -86,6 +91,14 @@ input.section-collapse:checked + label.section-collapse-label > h2 > i {
 label.section-collapse-label > h2 > i {
     margin-left: 10px;
     float: left;
+}
+
+div.pill-toggle {
+    @include pill-toggle;
+
+    &.min-content {
+        height: min-content;
+    }
 }
 
 input.attributes-collapse:checked ~ .attributes,

--- a/styles/dialog/character-burner.scss
+++ b/styles/dialog/character-burner.scss
@@ -330,14 +330,6 @@
         margin-bottom: 3em;
         width: 60%;
         grid-template-columns: 1fr 2fr;
-
-        .sheet-setting-toggle {
-            @include button-like(black);
-        }
-
-        input[type="checkbox"]:checked + .sheet-setting-toggle {
-            @include button-like-active;
-        }
     }
 
     .burner-finishing {

--- a/styles/items/spell.scss
+++ b/styles/items/spell.scss
@@ -12,14 +12,6 @@
         }
     }
 
-    .spell-toggle-label {
-        @include button-like(grey);
-    }
-
-    .spell-toggle-checkbox:checked + .spell-toggle-label {
-        @include button-like-active;
-    }
-
     .spell-setting-label {
         font-weight: bold;
     }

--- a/styles/mixins.scss
+++ b/styles/mixins.scss
@@ -113,3 +113,29 @@ $hover-color: rgba(0,0,0,0.1);
     border: 2px solid #005500;
     color: #005500;
 }
+
+@mixin pill-toggle {
+    display: flex;
+    & > input[type="checkbox"] {
+        opacity: 0;
+        width: 1px;
+        height: 1px;
+        margin: 0;
+        display: inline-block;
+        &:checked + label {
+            @include button-like-active;
+        }
+
+        &:focus + label {
+            border-color: green;
+        }
+    }
+
+    & > label {
+        margin-left: -20px;
+        display: block;
+        width: 100%;
+        @include button-like(black);
+    }
+
+}

--- a/templates/dialogs/character-burner.hbs
+++ b/templates/dialogs/character-burner.hbs
@@ -449,17 +449,25 @@
     </div>
     <div class="burner-settings burner-grid">
         <div class="burner-label whole-row">9a. A few sheet level settings...</div>
-        <input type="checkbox" id="armor-trained-check" class="hidden" name="settingArmorTrained">
-        <label for="armor-trained-check" class="sheet-setting-toggle">Armor Trained</label>
+        <div class="pill-toggle">
+            <input type="checkbox" id="armor-trained-check" name="settingArmorTrained">
+            <label for="armor-trained-check">Armor Trained</label>
+        </div>
         <div>Select this if the character has received armor training.</div>
-        <input type="checkbox" id="tough-check" class="hidden" name="settingTough">
-        <label for="tough-check" class="sheet-setting-toggle">Round up Mortal Wound</label>
+        <div class="pill-toggle">
+            <input type="checkbox" id="tough-check" name="settingTough">
+            <label for="tough-check">Round up Mortal Wound</label>
+        </div>
         <div>Select this if the character rounds up when factoring mortal wound such as from the Tough trait.</div>
-        <input type="checkbox" id="reflex-check" class="hidden" name="settingReflex">
-        <label for="reflex-check" class="sheet-setting-toggle">Round up Reflexes</label>
+        <div class="pill-toggle">
+            <input type="checkbox" id="reflex-check" name="settingReflex">
+            <label for="reflex-check" >Round up Reflexes</label>
+        </div>
         <div>Select this if the character rounds up when factoring reflexes such as from the Quickened Pulse trait.</div>
-        <input type="checkbox" id="numb-check" class="hidden" name="settingNumb">
-        <label for="numb-check" class="sheet-setting-toggle">Ignore Superficial</label>
+        <div class="pill-toggle">
+            <input type="checkbox" id="numb-check" name="settingNumb">
+            <label for="numb-check">Ignore Superficial</label>
+        </div>
         <div>Select this if the character ignores superficial wounds such as from the numb trait.</div>
     </div>
     <div class="burner-finishing burner-right-third">

--- a/templates/items/affiliation.hbs
+++ b/templates/items/affiliation.hbs
@@ -1,6 +1,7 @@
 <form autocomplete="off">
-    <input name="name" type="text" value="{{item.name}}">
-    <div class="item-grid">
+    <input name="name" type="text" value="{{item.name}}" class="item-sheet-name">
+    <div class="item-form-group">
+        <div class="item-setting-label">Dice</div>
         <select name="data.dice" value="{{data.dice}}" >
             {{#select data.dice}}
             <option value="0">None</option>

--- a/templates/items/possession.hbs
+++ b/templates/items/possession.hbs
@@ -2,11 +2,15 @@
     <input type="text" name="name" class="item-sheet-name" value="{{item.name}}">
     <div class="item-form-group">
         <label for="{{item._id}}-point-cost" class="item-setting-label">Resource Point Cost</label>
-        <input id="{{item._id}}-point-cost" type="number" class="exponent" name="data.pointCost" value="{{data.pointCost}}" data-dtype="Number">
-        <input id="{{item._id}}-checkbox-toolkit" class="item-setting-checkbox hidden" type="checkbox" name="data.isToolkit" {{checked data.isToolkit}}>
-        <label for="{{item._id}}-checkbox-toolkit" class="item-setting-toggle">Toolkit</label>
-        <input id="{{item._id}}-checkbox-expended" class="item-setting-checkbox hidden" type="checkbox" name="data.isExpended" {{checked data.isExpended}}>
-        <label for="{{item._id}}-checkbox-expended" class="item-setting-toggle">Expended</label>
+        <input id="{{item._id}}-point-cost" type="number" class="exponent no-arrows" name="data.pointCost" value="{{data.pointCost}}" data-dtype="Number">
+        <div class="pill-toggle min-content">
+            <input id="{{item._id}}-checkbox-toolkit" type="checkbox" name="data.isToolkit" {{checked data.isToolkit}}>
+            <label for="{{item._id}}-checkbox-toolkit" >Toolkit</label>
+        </div>
+        <div class="pill-toggle min-content">
+            <input id="{{item._id}}-checkbox-expended" type="checkbox" name="data.isExpended" {{checked data.isExpended}}>
+            <label for="{{item._id}}-checkbox-expended">Expended</label>
+        </div>
     </div>
     <hr/>
     <textarea name="data.description">{{data.description}}</textarea>

--- a/templates/items/property.hbs
+++ b/templates/items/property.hbs
@@ -5,9 +5,11 @@
     </div>
     <div class="item-form-group">
         <label for="{{item._id}}-point-cost" class="item-setting-label">Resource Point Cost</label>
-        <input id="{{item._id}}-point-cost" type="number" class="exponent" name="data.pointCost" value="{{data.pointCost}}" data-dtype="Number">
-        <input id="{{item._id}}-checkbox-isWorkshop" type="checkbox" class="item-setting-checkbox hidden" name="data.isWorkshop" {{checked data.isWorkshop}}>
-        <label for="{{item._id}}-checkbox-isWorkshop" class="item-setting-toggle">Workshop</label>
+        <input id="{{item._id}}-point-cost" type="number" class="exponent no-arrows" name="data.pointCost" value="{{data.pointCost}}" data-dtype="Number">
+        <div class="pill-toggle min-content">
+            <input id="{{item._id}}-checkbox-isWorkshop" type="checkbox" class="item-setting-checkbox hidden" name="data.isWorkshop" {{checked data.isWorkshop}}>
+            <label for="{{item._id}}-checkbox-isWorkshop" class="item-setting-toggle">Workshop</label>
+        </div>
     </div>
     
     <hr/>

--- a/templates/items/rangedWeapon.hbs
+++ b/templates/items/rangedWeapon.hbs
@@ -1,12 +1,14 @@
 <form autocomplete="off">
     <input name="name" type="text" class="item-sheet-name" value="{{item.name}}">
-    <hr/>
-    <h2>Stats</h2>
     <div class="item-form-group">
-        <input id="{{item._id}}-checkbox-usePower" class="item-setting-checkbox hidden" type="checkbox" name="data.usePower" {{checked data.usePower}}>
-        <label for="{{item._id}}-checkbox-usePower" class="item-setting-toggle">Use Power</label>
-        <input id="{{item._id}}-checkbox-hasGunpowder" class="item-setting-checkbox hidden" type="checkbox" name="data.hasGunpowder" {{checked data.hasGunpowder}}>
-        <label for="{{item._id}}-checkbox-hasGunpowder" class="item-setting-toggle">Use Gunpowder</label>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-checkbox-usePower" type="checkbox" name="data.usePower" {{checked data.usePower}}>
+            <label for="{{item._id}}-checkbox-usePower" >Use Power</label>
+        </div>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-checkbox-hasGunpowder" type="checkbox" name="data.hasGunpowder" {{checked data.hasGunpowder}}>
+            <label for="{{item._id}}-checkbox-hasGunpowder">Use Gunpowder</label>
+        </div>
     </div>
     <hr />
     {{#if data.usePower}}

--- a/templates/items/relationship.hbs
+++ b/templates/items/relationship.hbs
@@ -1,6 +1,5 @@
 <form autocomplete="off" class="relationship-sheet">
-    <label for="{{item._id}}-name-input">Name</label>
-    <input id="{{item._id}}-name-input" type="text" value="{{item.name}}" name="name">
+    <input id="{{item._id}}-name-input" type="text" value="{{item.name}}" name="name" class="item-sheet-name">
     <div class="checkbox-grid">
         <input id="{{item._id}}-checkbox-forbidden" type="checkbox" name="data.forbidden" {{checked data.forbidden}}>
         <label for="{{item._id}}-checkbox-forbidden">Forbidden</label>

--- a/templates/items/reputation.hbs
+++ b/templates/items/reputation.hbs
@@ -1,6 +1,7 @@
 <form autocomplete="off">
-    <input name="name" type="text" value="{{item.name}}">
-    <div class="item-grid">
+    <input name="name" type="text" value="{{item.name}}" class="item-sheet-name">
+    <div class="item-form-group">
+        <div class="item-setting-label">Dice</div>
         <select name="data.dice" value="{{data.dice}}" >
             {{#select data.dice}}
             <option value="0">None</option>
@@ -9,10 +10,11 @@
             <option value="3">3D</option>
             {{/select}}
         </select>
-        <div>
+        <div class="pill-toggle">
             <input id="{{item._id}}-checkbox-infamous" type="checkbox" name="data.infamous" {{checked data.infamous}}>
             <label for="{{item._id}}-checkbox-infamous">Infamous</label>
         </div>
     </div>
+    <hr>
     <textarea name="data.description">{{data.description}}</textarea>
 </form>

--- a/templates/items/skill.hbs
+++ b/templates/items/skill.hbs
@@ -39,16 +39,26 @@
     <div class="item-form-group">
         <label for="{{item._id}}-aptitude" class="item-setting-label">Aptitude</label>
         <input id="{{item._id}}-aptitude" type="number" name="data.aptitude" disabled value="{{data.aptitude}}" placeholder="N/A">
-        <input id="{{item._id}}-learning" class="item-setting-checkbox hidden" type="checkbox" name="data.learning" {{ checked data.learning }}>
-        <label for="{{item._id}}-learning" class="item-setting-toggle">Learning</label>
-        <input id="{{item._id}}-wild" class="item-setting-checkbox hidden" type="checkbox" name="data.wildFork" {{ checked data.wildFork }}>
-        <label for="{{item._id}}-wild" class="item-setting-toggle" title="This skill explodes on 1's and 6's when used as a fork.">Wild Fork</label>
-        <input id="{{item._id}}-open-skill" class="item-setting-checkbox hidden" type="checkbox" name="data.open" {{ checked data.open }}>
-        <label for="{{item._id}}-open-skill" class="item-setting-toggle">Open</label>
-        <input id="{{item._id}}-training" class="item-setting-checkbox hidden" type="checkbox" name="data.training" {{ checked data.training }}>
-        <label for="{{item._id}}-training" class="item-setting-toggle">Training Skill</label>
-        <input id="{{item._id}}-tools" class="item-setting-checkbox hidden" type="checkbox" name="data.tools" {{ checked data.tools }}>
-        <label for="{{item._id}}-tools" class="item-setting-toggle">Requires Tools</label>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-learning" type="checkbox" name="data.learning" {{ checked data.learning }}>
+            <label for="{{item._id}}-learning" >Learning</label>
+        </div>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-wild" type="checkbox" name="data.wildFork" {{ checked data.wildFork }}>
+            <label for="{{item._id}}-wild" title="This skill explodes on 1's and 6's when used as a fork.">Wild Fork</label>
+        </div>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-open-skill" type="checkbox" name="data.open" {{ checked data.open }}>
+            <label for="{{item._id}}-open-skill" >Open</label>
+        </div>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-training" type="checkbox" name="data.training" {{ checked data.training }}>
+            <label for="{{item._id}}-training" >Training Skill</label>
+        </div>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-tools" type="checkbox" name="data.tools" {{ checked data.tools }}>
+            <label for="{{item._id}}-tools" >Requires Tools</label>
+        </div>
     </div>
     <textarea name="data.description">{{data.description}}</textarea>
 </form>

--- a/templates/items/spell.hbs
+++ b/templates/items/spell.hbs
@@ -8,10 +8,14 @@
             type="text"
             name="data.variableObstacleDescription"
             value="{{data.variableObstacleDescription}}">
-        <input id="{{item._id}}-up-spell" class="hidden spell-toggle-checkbox" type="checkbox" name="data.upSpell" {{checked data.upSpell}}>
-        <label for="{{item._id}}-up-spell" class="spell-toggle-label">Up Spell</label>
-        <input id="{{item._id}}-var-obstacle" class="hidden spell-toggle-checkbox" type="checkbox" name="data.variableObstacle" {{checked data.variableObstacle}}>
-        <label for="{{item._id}}-var-obstacle" class="spell-toggle-label">Variable Ob</label>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-up-spell" type="checkbox" name="data.upSpell" {{checked data.upSpell}}>
+            <label for="{{item._id}}-up-spell">Up Spell</label>
+        </div>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-var-obstacle" type="checkbox" name="data.variableObstacle" {{checked data.variableObstacle}}>
+            <label for="{{item._id}}-var-obstacle">Variable Ob</label>
+        </div>
     </div>
     {{else}}
     <div class="spell-sheet-entry">
@@ -23,10 +27,14 @@
             name="data.obstacle"
             value="{{data.obstacle}}"
             class="exponent">
-        <input id="{{item._id}}-up-spell" class="hidden spell-toggle-checkbox" type="checkbox" name="data.upSpell" {{checked data.upSpell}}>
-        <label for="{{item._id}}-up-spell" class="spell-toggle-label">Up Spell</label>
-        <input id="{{item._id}}-var-obstacle" class="hidden spell-toggle-checkbox" type="checkbox" name="data.variableObstacle" {{checked data.variableObstacle}}>
-        <label for="{{item._id}}-var-obstacle" class="spell-toggle-label">Variable Ob</label>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-up-spell" type="checkbox" name="data.upSpell" {{checked data.upSpell}}>
+            <label for="{{item._id}}-up-spell">Up Spell</label>
+        </div>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-var-obstacle" type="checkbox" name="data.variableObstacle" {{checked data.variableObstacle}}>
+            <label for="{{item._id}}-var-obstacle">Variable Ob</label>
+        </div>
     </div>
     {{/if}}
     <div class="spell-sheet-entry">
@@ -68,12 +76,14 @@
             type="text"
             name="data.duration"
             value="{{data.duration}}">
-        <label for="{{item._id}}-point-cost" class="item-setting-label">Resource Point Cost</label>
+        <label for="{{item._id}}-point-cost" class="spell-setting-label">Resource Point Cost</label>
         <input id="{{item._id}}-point-cost" type="number" class="exponent" name="data.pointCost" onfocus="this.select();" value="{{data.pointCost}}" data-dtype="Number">
     </div>
     <div class="spell-weapon-toggle">
-        <input id="{{item._id}}-is-weapon" class="hidden spell-toggle-checkbox" type="checkbox" name="data.isWeapon" {{checked data.isWeapon}}>
-        <label for="{{item._id}}-is-weapon" class="spell-toggle-label">Is a Weapon</label>
+        <div class="pill-toggle">
+            <input id="{{item._id}}-is-weapon" type="checkbox" name="data.isWeapon" {{checked data.isWeapon}}>
+            <label for="{{item._id}}-is-weapon" class="spell-toggle-label">Is a Weapon</label>
+        </div>
     </div>
     <div class="spell-weapon-stats">
         {{#if data.isWeapon}}


### PR DESCRIPTION
Change checkboxes for toggles to be invisible, rather than hidden so
that they can be read by screen readers, be selected via keyboard, etc.

Resolves #117