### PR TITLE
Duel of Wits fixes

### DIFF
--- a/module/burningwheel.ts
+++ b/module/burningwheel.ts
@@ -48,6 +48,7 @@ Hooks.once("init", async () => {
         data
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
+    game.burningwheel.dow.activateSocketListeners();
 
 });
 

--- a/module/dialogs/duel-of-wits.ts
+++ b/module/dialogs/duel-of-wits.ts
@@ -30,7 +30,6 @@ export class DuelOfWitsDialog extends Dialog {
         html.find("input, select, textarea").on('change', (e) => this._propagateChange(e));
         html.find("button[data-action='reset-round']").on('click', (_) => this.clearRound());
         html.find("button[data-action='reset-everything']").on('click', (_) => this.clearEverything());
-        this.activateSocketListeners();
     }
 
     getData(): unknown {
@@ -121,7 +120,7 @@ export class DuelOfWitsDialog extends Dialog {
                 if (game.user.isGM) {
                     game.settings.set("burningwheel", "dow-data", JSON.stringify(this.data.data));
                 }
-                this.render(true);
+                if (this.rendered) { this.render(true); }
             }
         });
     }

--- a/module/dialogs/duel-of-wits.ts
+++ b/module/dialogs/duel-of-wits.ts
@@ -25,6 +25,21 @@ export class DuelOfWitsDialog extends Dialog {
         return mergeObject(super.defaultOptions, { width: 600, height: 600, resizable: true }, { overwrite: true });
     }
 
+    _getHeaderButtons(): { label: string, icon: string, class: string, onclick: (e: JQuery.ClickEvent) => void; }[] {
+        let buttons = super._getHeaderButtons();
+        if (game.user.isGM) {
+            buttons = [{
+                label: "Show",
+                icon: "fas fa-eye",
+                class: "force-show-dow",
+                onclick: (_) => {
+                    game.socket.emit("system.burningwheel", { type: "showDuel" });
+                }
+            }].concat(buttons);
+        }
+        return buttons;
+    }
+
     activateListeners(html: JQuery): void {
         html.submit((e) => { e.preventDefault(); });
         html.find("input, select, textarea").on('change', (e) => this._propagateChange(e));
@@ -121,6 +136,8 @@ export class DuelOfWitsDialog extends Dialog {
                     game.settings.set("burningwheel", "dow-data", JSON.stringify(this.data.data));
                 }
                 if (this.rendered) { this.render(true); }
+            } else if (type === "showDuel") {
+                this.render(true);
             }
         });
     }


### PR DESCRIPTION
Duel of wits no longer opens for all users whenever any data changes.
Duel of wits now properly registers listeners on initialization rather when first opened
Adds a new button in the duel of wits dialog to allow the GM to show the window to all players.

Resovles #141 