### PR TITLE
Fix fight clear all bug

### DIFF
--- a/module/dialogs/fight.ts
+++ b/module/dialogs/fight.ts
@@ -74,8 +74,10 @@ export class FightDialog extends ExtendedTestDialog<FightDialogData> {
             this.data.data.participants = [];
             this.data.data.participantIds = [];
             this.data.data.showV1 = this.data.data.showV2 = this.data.data.showV3 = false;
+            this.data.actors = [];
             this.syncData(this.data.data);
             this.persistState(this.data.data);
+            this._syncActors();
             this.render();
         });
 


### PR DESCRIPTION
Fixed a bug with clearing all fighters in the fight dialog leaving some
actors behind in the actor data cache.

Resolves #180 