### PR TITLE
Add ability to record wound recovery progress

### DIFF
--- a/module/character.ts
+++ b/module/character.ts
@@ -155,6 +155,9 @@ export class BWCharacter extends Actor<BWCharacterData>{
             woundDice --;
         }
 
+        woundDice = Math.max(0,
+            woundDice - (this.data.data.ptgs.woundRecovery1 || 0) - (this.data.data.ptgs.woundRecovery2 || 0) - (this.data.data.ptgs.woundRecovery3 || 0));
+
         this.data.data.ptgs.woundDice = woundDice;
     }
 
@@ -372,6 +375,9 @@ export interface Ptgs {
         woundNotes1: string,
         woundNotes2: string,
         woundNotes3: string,
+        woundRecovery1: number,
+        woundRecovery2: number,
+        woundRecovery3: number,
         shrugging: boolean, // shrug it off is active
         gritting: boolean, // grit your teeth is active
 

--- a/styles/character/ptgs.scss
+++ b/styles/character/ptgs.scss
@@ -105,6 +105,20 @@
             text-align: center;
         }
 
+        input {
+            width: 35%;
+            height: 1.75em;
+            font-weight: bold;
+            text-align: center;
+        }
+
+        .recovery-label {
+            width: 60%;
+            text-align: center;
+            line-height: 2em;
+            font-weight: bolder;
+        }
+
         textarea {
             resize: none;
             border: 0;

--- a/template.yml
+++ b/template.yml
@@ -26,6 +26,9 @@ Actor:
         woundNotes1: ''
         woundNotes2: ''
         woundNotes3: ''
+        woundRecovery1: 0
+        woundRecovery2: 0
+        woundRecovery3: 0
         shrugging: false
         gritting: false
     displayProps:

--- a/templates/parts/ptgs.hbs
+++ b/templates/parts/ptgs.hbs
@@ -51,13 +51,19 @@
 </div>
 <div class="ptgs-woundnotes1 flex-row">
     <h3>Injury Recovery</h3>
+    <div class="recovery-label">Recovered</div>
+    <input type="number" name="data.ptgs.woundRecovery1" value="{{ptgs.woundRecovery1}}" min="0">
     <textarea name="data.ptgs.woundNotes1">{{ptgs.woundNotes1}}</textarea>
 </div>
 <div class="ptgs-woundnotes2 flex-row">
     <h3>Injury Recovery</h3>
+    <div class="recovery-label">Recovered</div>
+    <input type="number" name="data.ptgs.woundRecovery2" value="{{ptgs.woundRecovery2}}" min="0">
     <textarea name="data.ptgs.woundNotes2">{{ptgs.woundNotes2}}</textarea>
 </div>
 <div class="ptgs-woundnotes3 flex-row">
     <h3>Injury Recovery</h3>
+    <div class="recovery-label">Recovered</div>
+    <input type="number" name="data.ptgs.woundRecovery3" value="{{ptgs.woundRecovery3}}" min="0">
     <textarea name="data.ptgs.woundNotes3">{{ptgs.woundNotes3}}</textarea>
 </div>


### PR DESCRIPTION
Adds 3 inputs to the PC sheet for recording partial recovery from
injuries. Numbers entered above the recovery notes subtract from the
wound dice directly.

Resolves #187