### PR TITLE
Split pool rerolls

### DIFF
--- a/module/rolls/fightRoll.ts
+++ b/module/rolls/fightRoll.ts
@@ -75,7 +75,7 @@ export async function handleFightRoll({actor, type, itemId, attackIndex, positio
     if (actor.data.type === "npc") {
         // npc specific code
         const dice = parseInt(getProperty(actor, `data.data.${type}.exp`));
-        const shade = getProperty(actor, `data.data.${type}.exp`) as ShadeString;
+        const shade = getProperty(actor, `data.data.${type}.shade`) as ShadeString;
         return handleNpcStatRoll({
             dice,
             shade,

--- a/module/rolls/npcSkillRoll.ts
+++ b/module/rolls/npcSkillRoll.ts
@@ -139,7 +139,7 @@ async function skillRollCallback(
     }
     extraInfo = `${splitPoolString || ""} ${extraInfo || ""}`;
 
-    const fateReroll = buildRerollData({ actor, roll, itemId: skill.id });
+    const fateReroll = buildRerollData({ actor, roll, itemId: skill.id, splitPoolRoll });
     const callons: RerollData[] = actor.getCallons(name).map(s => {
         return { label: s, ...buildRerollData({ actor, roll, splitPoolRoll, itemId: skill._id }) as RerollData };
     });

--- a/module/rolls/rerollCallon.ts
+++ b/module/rolls/rerollCallon.ts
@@ -9,9 +9,11 @@ export async function handleCallonReroll(target: HTMLButtonElement): Promise<unk
     const accessor = target.dataset.accessor || '';
     const name = target.dataset.rollName || '';
     const itemId = target.dataset.itemId || '';
-    const rollArray = target.dataset.dice?.split(',').map(s => parseInt(s, 10)) || [];
-    const successes = parseInt(target.dataset.successes || "0", 10);
-    const obstacleTotal = parseInt(target.dataset.difficulty || "0", 10);
+    const rollArray = target.dataset.dice?.split(',').map(r => parseInt(r)) || [];
+    const splitRollArray = target.dataset.splitDice?.split(',').map(r => parseInt(r)) || [];
+    const successes = parseInt(target.dataset.successes || "0");
+    const obstacleTotal = parseInt(target.dataset.difficulty || "0");
+    const splitSuccesses = parseInt(target.dataset.splitSuccesses || "0");
 
     let rollStat: Ability | SkillData;
     if (target.dataset.rerollType === "stat") {
@@ -23,64 +25,81 @@ export async function handleCallonReroll(target: HTMLButtonElement): Promise<unk
     const successTarget = rollStat.shade === "B" ? 3 : (rollStat.shade === "G" ? 2 : 1);
 
     const numDice = rollArray.filter(r => r <= successTarget).length || 0;
-    const reroll = await rollDice(numDice, rollStat.open, rollStat.shade);
+    const numSplitDice = splitRollArray.filter(r => r <= successTarget).length || 0;
+    
+    const reroll = numDice ? await rollDice(numDice, rollStat.open, rollStat.shade) : undefined;
+    const splitReroll = numSplitDice ? await rollDice(numSplitDice, rollStat.open, rollStat.shade) : undefined;
 
-    if (!reroll) { return; }
-    const newSuccesses = parseInt(reroll.result, 10);
-    const success = (newSuccesses + successes) >= obstacleTotal;
-    if (actor.data.type === "character") {
-        // only characters worry about turning failures into successes.
-        // NPCs don't track things closely enough.
-        if (target.dataset.rerollType === "stat") {
-            if (successes <= obstacleTotal && success) {
-                // we turned a failure into a success. we might need to retroactively award xp.
-                if (target.dataset.ptgsAction) { // shrug/grit flags may need to be set.
-                    const updateData = {};
-                    updateData[`data.ptgs.${target.dataset.ptgsAction}`] = true;
-                    actor.update(updateData);
-                }
-                if (actor.data.successOnlyRolls.indexOf(name.toLowerCase()) !== -1) {
-                    if (!helpers.isStat(name)) {
-                        actor.addAttributeTest(
-                            getProperty(actor, `data.${accessor}`) as TracksTests,
-                            name,
-                            accessor,
-                            target.dataset.difficultyGroup as TestString,
-                            true);
-                    }
-                    else {
-                        actor.addStatTest(
-                            getProperty(actor, `data.${accessor}`) as TracksTests,
-                            name,
-                            accessor,
-                            target.dataset.difficultyGroup as TestString,
-                            true);
-                    }
-                }
-            }
+    let newSuccesses = 0;
+    let success = false;
 
-        } else if (target.dataset.rerollType === "learning") {
-            const learningTarget = target.dataset.learningTarget || 'skill';
-            if (learningTarget === 'perception' && successes <= obstacleTotal && success) {
-                // we need to give perception a success that was not counted
-                actor.addStatTest(
-                    getProperty(actor, "data.data.perception") as TracksTests,
-                    "Perception",
-                    "data.perception",
-                    target.dataset.difficultyGroup as TestString,
-                    true);
+    if (!numDice && !numSplitDice) { return; }
+    if (reroll) {
+        newSuccesses = reroll.total || 0;
+        success = (newSuccesses + successes) >= obstacleTotal;
+        if (actor.data.type === "character") {
+            // only characters worry about turning failures into successes.
+            // NPCs don't track things closely enough.
+            if (target.dataset.rerollType === "stat") {
+                if (successes <= obstacleTotal && success) {
+                    // we turned a failure into a success. we might need to retroactively award xp.
+                    if (target.dataset.ptgsAction) { // shrug/grit flags may need to be set.
+                        const updateData = {};
+                        updateData[`data.ptgs.${target.dataset.ptgsAction}`] = true;
+                        actor.update(updateData);
+                    }
+                    if (actor.data.successOnlyRolls.indexOf(name.toLowerCase()) !== -1) {
+                        if (!helpers.isStat(name)) {
+                            actor.addAttributeTest(
+                                getProperty(actor, `data.${accessor}`) as TracksTests,
+                                name,
+                                accessor,
+                                target.dataset.difficultyGroup as TestString,
+                                true);
+                        }
+                        else {
+                            actor.addStatTest(
+                                getProperty(actor, `data.${accessor}`) as TracksTests,
+                                name,
+                                accessor,
+                                target.dataset.difficultyGroup as TestString,
+                                true);
+                        }
+                    }
+                }
+
+            } else if (target.dataset.rerollType === "learning") {
+                const learningTarget = target.dataset.learningTarget || 'skill';
+                if (learningTarget === 'perception' && successes <= obstacleTotal && success) {
+                    // we need to give perception a success that was not counted
+                    actor.addStatTest(
+                        getProperty(actor, "data.data.perception") as TracksTests,
+                        "Perception",
+                        "data.perception",
+                        target.dataset.difficultyGroup as TestString,
+                        true);
+                }
             }
         }
+    }
+
+    let newSplitSuccesses = 0;
+    if (splitReroll) {
+        newSplitSuccesses = splitReroll.total || 0;
     }
 
     const data: RerollMessageData = {
         title: "Call-on Reroll",
         rolls: rollArray.map(r => { return { roll: r, success: r > successTarget }; }),
-        rerolls: reroll.dice[0].results.map(r => { return { roll: r.result, success: r.success || false }; }),
+        splitRolls: splitRollArray.map(r => { return { roll: r, success: r > successTarget }; }),
+        rerolls: reroll?.dice[0].results.map(r => { return { roll: r.result, success: r.success || false }; }) || [],
+        splitRerolls: splitReroll?.dice[0].results.map(r => { return { roll: r.result, success: r.success || false }; }) || [],
         successes,
         obstacleTotal,
         newSuccesses,
-        success
+        success,
+        splitSuccesses,
+        newSplitSuccesses
     };
     const html = await renderTemplate(templates.rerollChatMessage, data);
     return ChatMessage.create({
@@ -93,9 +112,13 @@ export async function handleCallonReroll(target: HTMLButtonElement): Promise<unk
 export interface RerollMessageData {
     title: string;
     rolls: { roll: number, success: boolean }[];
+    splitRolls: { roll: number, success: boolean }[];
     rerolls: { roll: number, success: boolean }[];
+    splitRerolls: { roll: number, success: boolean }[];
     success: boolean;
     successes: number;
     newSuccesses: number;
+    splitSuccesses: number;
+    newSplitSuccesses: number;
     obstacleTotal: number;
 }

--- a/module/rolls/rerollCallon.ts
+++ b/module/rolls/rerollCallon.ts
@@ -2,7 +2,7 @@ import { TestString } from "../helpers.js";
 import { Ability, TracksTests, BWCharacter } from "../bwactor.js";
 import * as helpers from "../helpers.js";
 import { Skill, SkillData } from "../items/item.js";
-import { rollDice, templates } from "./rolls.js";
+import { getNoDiceErrorDialog, RerollMessageData, rollDice, templates } from "./rolls.js";
 
 export async function handleCallonReroll(target: HTMLButtonElement): Promise<unknown> {
     const actor = game.actors.get(target.dataset.actorId || "") as BWCharacter;
@@ -33,7 +33,7 @@ export async function handleCallonReroll(target: HTMLButtonElement): Promise<unk
     let newSuccesses = 0;
     let success = false;
 
-    if (!numDice && !numSplitDice) { return; }
+    if (!numDice && !numSplitDice) { return getNoDiceErrorDialog(0); }
     if (reroll) {
         newSuccesses = reroll.total || 0;
         success = (newSuccesses + successes) >= obstacleTotal;
@@ -106,19 +106,4 @@ export async function handleCallonReroll(target: HTMLButtonElement): Promise<unk
         content: html,
         speaker: ChatMessage.getSpeaker({actor})
     });
-}
-
-
-export interface RerollMessageData {
-    title: string;
-    rolls: { roll: number, success: boolean }[];
-    splitRolls: { roll: number, success: boolean }[];
-    rerolls: { roll: number, success: boolean }[];
-    splitRerolls: { roll: number, success: boolean }[];
-    success: boolean;
-    successes: number;
-    newSuccesses: number;
-    splitSuccesses: number;
-    newSplitSuccesses: number;
-    obstacleTotal: number;
 }

--- a/module/rolls/rerollFate.ts
+++ b/module/rolls/rerollFate.ts
@@ -2,7 +2,7 @@ import { TestString } from "../helpers.js";
 import { BWActor, TracksTests, BWCharacter } from "../bwactor.js";
 import * as helpers from "../helpers.js";
 import { Skill, Armor } from "../items/item.js";
-import { RerollMessageData, rollDice, templates } from "./rolls.js";
+import { getNoDiceErrorDialog, RerollMessageData, rollDice, templates } from "./rolls.js";
 
 export async function handleFateReroll(target: HTMLButtonElement): Promise<unknown> {
     const actor = game.actors.get(target.dataset.actorId || "") as BWActor;
@@ -12,6 +12,8 @@ export async function handleFateReroll(target: HTMLButtonElement): Promise<unkno
     const rollArray = target.dataset.dice?.split(',').map(s => parseInt(s, 10)) || [];
     const successes = parseInt(target.dataset.successes || "0", 10);
     const obstacleTotal = parseInt(target.dataset.difficulty || "0", 10);
+    const splitRollArray = target.dataset.splitDice?.split(',').map(r => parseInt(r)) || [];
+    const splitSuccesses = parseInt(target.dataset.splitSuccesses || "0");
 
     let rollStat: { shade: helpers.ShadeString, open: boolean };
     if (target.dataset.rerollType === "stat") {
@@ -26,90 +28,115 @@ export async function handleFateReroll(target: HTMLButtonElement): Promise<unkno
     const successTarget = rollStat.shade === "B" ? 3 : (rollStat.shade === "G" ? 2 : 1);
 
     let reroll: Roll | undefined;
+    let splitReroll: Roll | undefined;
+    let numDice = 0;
+    let splitNumDice = 0;
+
     if (rollStat.open) {
         // only reroll dice if there were any traitors
-        const numDice = rollArray.filter(r => r <= successTarget).length ? 1 : 0;
-        reroll = await rollDice(numDice, false, rollStat.shade);
+        numDice = rollArray.some(r => r <= successTarget) ? 1 : 0;
+        splitNumDice = numDice ? 0 : (splitRollArray.some(r => r <= successTarget) ? 1 : 0);
     } else {
-        const numDice = rollArray.filter(s => s === 6).length;
-        reroll = await rollDice(numDice, true, rollStat.shade);
+        numDice = rollArray.filter(s => s === 6).length;
+        splitNumDice = splitRollArray.filter(s => s === 6).length;
     }
 
-    if (!reroll) { return; }
-    const newSuccesses = parseInt(reroll.result, 10);
-    const success = (newSuccesses + successes) >= obstacleTotal;
+    if (numDice) { 
+        reroll = await rollDice(numDice, !rollStat.open, rollStat.shade);
+    }
+    if (splitNumDice) {
+        splitReroll = await rollDice(splitNumDice, !rollStat.open, rollStat.shade);
+    }
 
-    if (actor.data.data.fate !== "0" && actor.data.type === "character") {
-        if (target.dataset.rerollType === "stat") {
-            const fateSpent = parseInt(getProperty(actor, `data.${accessor}.fate`) || "0", 10);
-            const updateData = {};
-            updateData[`${accessor}.fate`] = fateSpent + 1;
-            if (successes <= obstacleTotal && success) {
-                // we turned a failure into a success. we might need to retroactively award xp.
-                if (target.dataset.ptgsAction) { // shrug/grit flags may need to be set.
-                    updateData[`data.ptgs.${target.dataset.ptgsAction}`] = true;
-                }
-                if (actor.data.successOnlyRolls.indexOf(name.toLowerCase()) !== -1) {
-                    if (!helpers.isStat(name)) {
-                        (actor as BWActor & BWCharacter).addAttributeTest(
-                            getProperty(actor, `data.${accessor}`) as TracksTests,
-                            name,
-                            accessor,
-                            target.dataset.difficultyGroup as TestString,
-                            true);
-                    }
-                    else {
-                        (actor as BWActor & BWCharacter).addStatTest(
-                            getProperty(actor, `data.${accessor}`) as TracksTests,
-                            name,
-                            accessor,
-                            target.dataset.difficultyGroup as TestString,
-                            true);
-                    }
-                }
-            }
-            actor.update(updateData);
-        } else if (target.dataset.rerollType === "skill") {
-            const skill = actor.getOwnedItem(itemId) as Skill;
-            const fateSpent = parseInt(skill.data.data.fate, 10) || 0;
-            skill.update({ 'data.fate': fateSpent + 1 }, {});
-        } else if (target.dataset.rerollType === "learning") {
-            const learningTarget = target.dataset.learningTarget || 'skill';
-            const skill = actor.getOwnedItem(itemId) as Skill;
-            if (learningTarget === 'skill') {
-                // learning roll went to the root skill
-                const fateSpent = parseInt(skill.data.data.fate, 10) || 0;
-                skill.update({'data.fate': fateSpent + 1 }, {});
-            } else {
-                if (successes <= obstacleTotal && success) {
-                    if (learningTarget === "perception") {
-                        (actor as BWActor & BWCharacter).addStatTest(
-                            getProperty(actor, "data.data.perception") as TracksTests,
-                            "Perception",
-                            "data.perception",
-                            target.dataset.difficultyGroup as TestString,
-                            true);
-                    }
-                }
-                const rootAccessor = `data.${learningTarget}.fate`;
-                const rootStatFate = parseInt(getProperty(actor, `data.${rootAccessor}`), 10) || 0;
+
+    if (!reroll && !splitReroll) { return getNoDiceErrorDialog(0); }
+    let newSuccesses = 0;
+    let success = false;
+    if (reroll) {
+        newSuccesses = reroll.total || 0;
+        success = (newSuccesses + successes) >= obstacleTotal;
+
+        if (actor.data.data.fate !== "0" && actor.data.type === "character") {
+            if (target.dataset.rerollType === "stat") {
+                const fateSpent = parseInt(getProperty(actor, `data.${accessor}.fate`) || "0", 10);
                 const updateData = {};
-                updateData[rootAccessor] = rootStatFate + 1;
+                updateData[`${accessor}.fate`] = fateSpent + 1;
+                if (successes <= obstacleTotal && success) {
+                    // we turned a failure into a success. we might need to retroactively award xp.
+                    if (target.dataset.ptgsAction) { // shrug/grit flags may need to be set.
+                        updateData[`data.ptgs.${target.dataset.ptgsAction}`] = true;
+                    }
+                    if (actor.data.successOnlyRolls.indexOf(name.toLowerCase()) !== -1) {
+                        if (!helpers.isStat(name)) {
+                            (actor as BWActor & BWCharacter).addAttributeTest(
+                                getProperty(actor, `data.${accessor}`) as TracksTests,
+                                name,
+                                accessor,
+                                target.dataset.difficultyGroup as TestString,
+                                true);
+                        }
+                        else {
+                            (actor as BWActor & BWCharacter).addStatTest(
+                                getProperty(actor, `data.${accessor}`) as TracksTests,
+                                name,
+                                accessor,
+                                target.dataset.difficultyGroup as TestString,
+                                true);
+                        }
+                    }
+                }
                 actor.update(updateData);
+            } else if (target.dataset.rerollType === "skill") {
+                const skill = actor.getOwnedItem(itemId) as Skill;
+                const fateSpent = parseInt(skill.data.data.fate, 10) || 0;
+                skill.update({ 'data.fate': fateSpent + 1 }, {});
+            } else if (target.dataset.rerollType === "learning") {
+                const learningTarget = target.dataset.learningTarget || 'skill';
+                const skill = actor.getOwnedItem(itemId) as Skill;
+                if (learningTarget === 'skill') {
+                    // learning roll went to the root skill
+                    const fateSpent = parseInt(skill.data.data.fate, 10) || 0;
+                    skill.update({'data.fate': fateSpent + 1 }, {});
+                } else {
+                    if (successes <= obstacleTotal && success) {
+                        if (learningTarget === "perception") {
+                            (actor as BWActor & BWCharacter).addStatTest(
+                                getProperty(actor, "data.data.perception") as TracksTests,
+                                "Perception",
+                                "data.perception",
+                                target.dataset.difficultyGroup as TestString,
+                                true);
+                        }
+                    }
+                    const rootAccessor = `data.${learningTarget}.fate`;
+                    const rootStatFate = parseInt(getProperty(actor, `data.${rootAccessor}`), 10) || 0;
+                    const updateData = {};
+                    updateData[rootAccessor] = rootStatFate + 1;
+                    actor.update(updateData);
+                }
             }
-        }
 
-        const actorFateCount = parseInt(actor.data.data.fate, 10);
-        actor.update({ 'data.fate': actorFateCount -1 });
+            const actorFateCount = parseInt(actor.data.data.fate, 10);
+            actor.update({ 'data.fate': actorFateCount -1 });
+        }
+    }
+
+    let newSplitSuccesses = 0;
+    if (splitReroll) {
+        newSplitSuccesses = splitReroll.total || 0;
     }
 
     const data: RerollMessageData = {
         title: "Fate Reroll",
         rolls: rollArray.map(r => { return { roll: r, success: r > successTarget }; }),
-        rerolls: reroll.dice[0].results.map(r => { return { roll: r.result, success: r.success || false }; }),
+        splitRolls: splitRollArray.map(r => { return { roll: r, success: r > successTarget }; }),
+        splitRerolls: splitReroll?.dice[0].results.map(r => { return { roll: r.result, success: r.success || false }; }) || [],
+        rerolls: reroll?.dice[0].results.map(r => { return { roll: r.result, success: r.success || false }; }) || [],
         successes,
+        splitSuccesses,
         obstacleTotal,
         newSuccesses,
+        newSplitSuccesses,
         success
     };
     const html = await renderTemplate(templates.rerollChatMessage, data);

--- a/module/rolls/rollSkill.ts
+++ b/module/rolls/rollSkill.ts
@@ -15,7 +15,7 @@ import {
     extractRollData,
     EventHandlerOptions,
     RollOptions,
-    mergeDialogData, getSplitPoolText
+    mergeDialogData, getSplitPoolText, getSplitPoolRoll
 } from "./rolls.js";
 import { BWCharacter } from "module/character.js";
 
@@ -78,8 +78,10 @@ async function skillRollCallback(
     const wildForkDice = wildForkDie?.results || [];
     
     let splitPoolString: string | undefined;
+    let splitPoolRoll: Roll | undefined;
     if (splitPool) {
-        splitPoolString = await getSplitPoolText(splitPool, skill.data.data.open, skill.data.data.shade);
+        splitPoolRoll = await getSplitPoolRoll(splitPool, skill.data.data.open, skill.data.data.shade);
+        splitPoolString = getSplitPoolText(splitPoolRoll);
     }
     extraInfo = `${splitPoolString || ""} ${extraInfo || ""}`;
 
@@ -97,15 +99,16 @@ async function skillRollCallback(
         }
     }
 
-    const fateReroll = buildRerollData({ actor, roll, itemId: skill._id });
+    const fateReroll = buildRerollData({ actor, roll, itemId: skill._id, splitPoolRoll });
     const callons: RerollData[] = actor.getCallons(skill.name).map(s => {
-        return { label: s, ...buildRerollData({ actor, roll, itemId: skill._id }) as RerollData };
+        return { label: s, ...buildRerollData({ actor, roll, itemId: skill._id, splitPoolRoll }) as RerollData };
     });
     const success = (parseInt(roll.result) + wildForkBonus) >= difficultyTotal;
 
     const data: RollChatMessageData = {
         name: `${skill.name}`,
         successes: '' + (parseInt(roll.result) + wildForkBonus),
+        splitSuccesses: splitPoolRoll ? splitPoolRoll.result : undefined,
         difficulty: baseDifficulty,
         obstacleTotal: difficultyTotal,
         nameClass: getRollNameClass(skill.data.data.open, skill.data.data.shade),

--- a/module/rolls/rolls.ts
+++ b/module/rolls/rolls.ts
@@ -528,10 +528,14 @@ export interface RerollData {
 export interface RerollMessageData {
     title: string;
     rolls: { roll: number, success: boolean }[];
+    splitRolls: { roll: number, success: boolean }[];
     rerolls: { roll: number, success: boolean }[];
+    splitRerolls: { roll: number, success: boolean }[];
     success: boolean;
     successes: number;
     newSuccesses: number;
+    splitSuccesses: number;
+    newSplitSuccesses: number;
     obstacleTotal: number;
 }
 

--- a/styles/chat/dialog.scss
+++ b/styles/chat/dialog.scss
@@ -66,6 +66,10 @@
             flex: 0 0 2.5em;
             margin-right: 5px;
             text-align: center;
+
+            &:enabled {
+                background-color: white;
+            }
         }
 
         select {

--- a/templates/chat/reroll-message.hbs
+++ b/templates/chat/reroll-message.hbs
@@ -2,6 +2,7 @@
     <div class="roll-full-width message-title">
         {{title}}
     </div>
+    {{#if rerolls}}
     <div class="roll-half-width">
         <label>Successes</label>
         <div>{{ successes }} + {{ newSuccesses }} </div>
@@ -30,6 +31,26 @@
     {{else}}
     <div class="roll-result roll-full-width roll-failure">
         Failure!
+    </div>
+    {{/if}}
+    {{/if}}
+    {{#if splitRerolls}}
+    <div class="roll-full-width roll-extra-info">
+        <div>Secondary Successes</div>
+        <div class="secondary-pool">{{splitSuccesses}} + {{newSplitSuccesses}}</div>
+    </div>
+    <div class="roll-full-width flex-row roll-dice">
+        {{#each splitRolls as |r|}}
+        <div class="roll-die" data-success="{{r.success}}">
+            {{r.roll}}
+        </div>
+        {{/each}}
+        <div class="vertical-divider"></div>
+        {{#each splitRerolls as |r|}}
+        <div class="roll-die" data-success="{{r.success}}">
+            {{r.roll}}
+        </div>
+    {{/each}}
     </div>
     {{/if}}
 </div>

--- a/templates/chat/roll-message.hbs
+++ b/templates/chat/roll-message.hbs
@@ -81,7 +81,7 @@
                 {{#if c.ptgsAction}} data-ptgs-action="{{c.ptgsAction}}" {{/if}}
                 data-difficulty="{{../obstacleTotal}}"
                 data-successes="{{../successes}}"
-                data-split-successes="{{splitSuccesses}}"
+                data-split-successes="{{../splitSuccesses}}"
                 data-difficulty-group="{{../difficultyGroup}}">Call-on: {{c.label}}</button>
         </div>
         {{/each}}

--- a/templates/chat/roll-message.hbs
+++ b/templates/chat/roll-message.hbs
@@ -73,6 +73,7 @@
                 data-actor-id="{{c.actorId}}"
                 data-reroll-type="{{c.type}}"
                 data-dice="{{c.dice}}"
+                {{#if c.splitDice}}data-split-dice="{{c.splitDice}}"{{/if}}
                 data-roll-name="{{../name}}"
                 {{#if c.itemId}} data-item-id="{{c.itemId}}" {{/if}}
                 {{#if c.accessor}} data-accessor="{{c.accessor}}" {{/if}}
@@ -80,6 +81,7 @@
                 {{#if c.ptgsAction}} data-ptgs-action="{{c.ptgsAction}}" {{/if}}
                 data-difficulty="{{../obstacleTotal}}"
                 data-successes="{{../successes}}"
+                data-split-successes="{{splitSuccesses}}"
                 data-difficulty-group="{{../difficultyGroup}}">Call-on: {{c.label}}</button>
         </div>
         {{/each}}
@@ -89,6 +91,7 @@
                 data-actor-id="{{fateReroll.actorId}}"
                 data-reroll-type="{{fateReroll.type}}"
                 data-dice="{{fateReroll.dice}}"
+                {{#if fateReroll.splitDice}}data-split-dice="{{fateReroll.splitDice}}"{{/if}}
                 data-roll-name="{{name}}"
                 {{#if fateReroll.itemId}} data-item-id="{{fateReroll.itemId}}" {{/if}}
                 {{#if fateReroll.accessor}} data-accessor="{{fateReroll.accessor}}" {{/if}}
@@ -96,6 +99,7 @@
                 {{#if fateReroll.ptgsAction}} data-ptgs-action="{{fateReroll.ptgsAction}}" {{/if}}
                 data-difficulty="{{obstacleTotal}}"
                 data-successes="{{successes}}"
+                data-split-successes="{{splitSuccesses}}"
                 data-difficulty-group="{{difficultyGroup}}">Reroll with Fate</button>
         </div>
         {{/if}}


### PR DESCRIPTION
Resolves #184 - Enable split pool rerolls.

Rerolling with fate and call-ons will now correctly also reroll the secondary die pool.
In the case of open-ended skills, the fate point applies to only one of the pools at any given time.