### PR TITLE
Emotional skills

### DIFF
--- a/module/dialogs/burnerDataHelpers.ts
+++ b/module/dialogs/burnerDataHelpers.ts
@@ -87,11 +87,11 @@ export function extractBaseCharacterData(html: JQuery<HTMLElement>): StringIndex
 
     baseData.custom1 = {
         name: extractNamedString(html, "custom1Name"),
-        ...getAttrData(html, "custom1")
+        ...getStatData(html, "custom1")
     };
     baseData.custom2 = {
         name: extractNamedString(html, "custom2Name"),
-        ...getAttrData(html, "custom2")
+        ...getStatData(html, "custom2")
     };
 
     const settings: Partial<CharacterSettings> = {

--- a/module/dialogs/characterBurner.ts
+++ b/module/dialogs/characterBurner.ts
@@ -183,19 +183,20 @@ export class CharacterBurnerDialog extends Dialog {
             }),
             html.find("input[name='skillPtsSpent'], input[name='combinedSkillPts']").on('change', _ =>
                 this._storeDiff(html, "skillPtsLeft", "combinedSkillPts", "skillPtsSpent")),
-            html.find("select[name='skillName']").on('input', (e: JQueryInputEventObject) => this._tryLoadSkill(e)),
+            html.find("select[name='skillName']").on('input', (e) => this._tryLoadSkill(e)),
             html.find("input[name='skillAdvances'], input[name='skillOpened'], input[name='skillTraining'], select[name='skillShade']").on('change', (e: JQuery.ChangeEvent) =>
                 this._calculateSkillWorth(e)),
             html.find("input[name='skillPtsWorth']").on('change', _ => this._storeSum(html, "skillPtsSpent", "skillPtsWorth")),
 
             html.find("*[name='powerSpent'], *[name='powerShadeSpent'], *[name='forteSpent'], *[name='forteShadeSpent'], " +
                 "*[name='agilitySpent'], *[name='agilityShadeSpent'], *[name='speedSpent'], *[name='speedShadeSpent'], " + 
-                "*[name='willSpent'], *[name='willShadeSpent'], *[name='perceptionSpent'], *[name='perceptionShadeSpent']").on('change', e => 
+                "*[name='willSpent'], *[name='willShadeSpent'], *[name='perceptionSpent'], *[name='perceptionShadeSpent']," + 
+                "*[name='custom1Spent'], *[name='custom1Shade'], *[name='custom2Spent'], *[name='custom2Shade']").on('change', e => 
                 this._calculateAllSkillExponents(e, html)),
             html.find("input[name='skillOpened'], input[name='skillAdvances'], select[name='skillRoot1'], select[name='skillRoot2']").on('change', (e: JQuery.ChangeEvent) => this._calculateSkillExponent(e.currentTarget, html)),
 
             // trait points spent
-            html.find("select[name='traitName']").on('input', (e: JQueryInputEventObject) => this._tryLoadTrait(e)),
+            html.find("select[name='traitName']").on('input', (e) => this._tryLoadTrait(e)),
             html.find("input[name='traitCost'], input[name='traitTaken']").on('change', _ => this._calculateSpentTraits(html)),
             html.find("input[name='traitPtsSpent'], input[name='traitPtsTotal']").on('change', _ => this._storeDiff(html, "traitPtsLeft", "traitPtsTotal", "traitPtsSpent")),
 
@@ -215,10 +216,10 @@ export class CharacterBurnerDialog extends Dialog {
             html.find("input[name='relationshipCost']").on('change', _e => this._storeSum(html, "relationshipsSpent", "relationshipCost")),
 
             // property
-            html.find("select[name='propertyName']").on('input', (e: JQueryInputEventObject) => this._tryLoadProperty(e)),
+            html.find("select[name='propertyName']").on('input', (e: JQuery.TriggeredEvent) => this._tryLoadProperty(e)),
             html.find("input[name='propertyCost']").on('change', _ => this._storeSum(html, "propertySpent", "propertyCost")),
             // gear
-            html.find("select[name='itemName']").on('input', (e: JQueryInputEventObject) => this._tryLoadGear(e)),
+            html.find("select[name='itemName']").on('input', (e: JQuery.TriggeredEvent) => this._tryLoadGear(e)),
             html.find("input[name='itemCost']").on('change', _ => this._storeSum(html, "gearSpent", "itemCost")),
 
             // extra rules totals
@@ -323,7 +324,7 @@ export class CharacterBurnerDialog extends Dialog {
         parent.children("*[name='skillPtsWorth']").val(advances + shade + open + training + refund).change();
     }
 
-    _tryLoadTrait(e: JQueryInputEventObject): void {
+    _tryLoadTrait(e: JQuery.TriggeredEvent): void {
         const inputTarget = $(e.currentTarget);
         const traitName = inputTarget.val() as string;
         if (!traitName) {
@@ -347,7 +348,7 @@ export class CharacterBurnerDialog extends Dialog {
         }
     }
 
-    private _tryLoadSkill(e: JQueryInputEventObject): void {
+    private _tryLoadSkill(e: JQuery.TriggeredEvent): void {
         const inputTarget = $(e.currentTarget);
         const skillName = inputTarget.val() as string;
         if (!skillName) {
@@ -369,7 +370,7 @@ export class CharacterBurnerDialog extends Dialog {
         }
     }
 
-    private _tryLoadProperty(e: JQueryInputEventObject): void {
+    private _tryLoadProperty(e: JQuery.TriggeredEvent): void {
         const inputTarget = $(e.currentTarget);
         const propertyName = inputTarget.val() as string;
         if (!propertyName) {
@@ -390,7 +391,7 @@ export class CharacterBurnerDialog extends Dialog {
         }
     }
 
-    private _tryLoadGear(e: JQueryInputEventObject): void {
+    private _tryLoadGear(e: JQuery.TriggeredEvent): void {
         const inputTarget = $(e.currentTarget);
         const gearName = inputTarget.val() as string;
         if (!gearName) {

--- a/module/items/sheets/skill-sheet.ts
+++ b/module/items/sheets/skill-sheet.ts
@@ -1,4 +1,5 @@
-import { skillRootSelect, skillTypeSelect } from "../../constants.js";
+import { skillTypeSelect } from "../../constants.js";
+import { Skill } from "../skill.js";
 
 export class SkillSheet extends ItemSheet {
     static get defaultOptions(): FormApplicationOptions {
@@ -11,8 +12,10 @@ export class SkillSheet extends ItemSheet {
 
     getData(): SkillSheetData {
         const data = super.getData() as SkillSheetData;
+
         data.skillTypes = skillTypeSelect;
-        data.skillRoots = skillRootSelect;
+        data.skillRoots = {};
+        Object.assign(data.skillRoots, (this.item as Skill).getRootSelect());
         return data;
     }
 }

--- a/module/items/skill.ts
+++ b/module/items/skill.ts
@@ -1,8 +1,25 @@
+import { skillRootSelect } from "../constants.js";
 import { Ability, BWActor, TracksTests } from "../bwactor.js";
-import { ShadeString, updateTestsNeeded } from "../helpers.js";
+import { ShadeString, StringIndexedObject, updateTestsNeeded } from "../helpers.js";
 import { DisplayClass, ItemType, BWItemData, BWItem } from "./item.js";
 
 export class Skill extends BWItem {
+    getRootSelect(): StringIndexedObject<string> {
+        const roots = {};
+        Object.assign(roots, skillRootSelect);
+        if (this.data.hasOwner && this.actor.data.type === "character") {
+            if (this.actor.data.data.custom1.name) {
+                roots["custom1"] = this.actor.data.data.custom1.name;
+            }
+            if (this.actor.data.data.custom2.name) {
+                roots["custom2"] = this.actor.data.data.custom2.name;
+            }
+        } else {
+            roots["custom1"] = "Custom Attribute 1";
+            roots["custom2"] = "Custom Attribute 2";
+        }
+        return roots;
+    }
     prepareData(): void {
         super.prepareData();
         updateTestsNeeded(this.data.data);

--- a/module/rolls/rollLearning.ts
+++ b/module/rolls/rollLearning.ts
@@ -233,7 +233,13 @@ async function advanceBaseStat(
 
     const accessor = `data.${statName.toLowerCase()}`;
     const rootStat = getProperty(owner, `data.${accessor}`);
-    await owner.addStatTest(rootStat, statName, accessor, difficultyGroup, isSuccessful);
+    if (statName === "custom1" || statName === "custom2") {
+        statName = owner.data.data[statName].name.titleCase();
+        await owner.addAttributeTest(rootStat, statName, accessor, difficultyGroup, isSuccessful);
+    } else {
+        await owner.addStatTest(rootStat, statName, accessor, difficultyGroup, isSuccessful);
+    }
+    
     return cb(fr);
 }
 

--- a/templates/dialogs/character-burner.hbs
+++ b/templates/dialogs/character-burner.hbs
@@ -162,6 +162,8 @@
                 <option value="forte">Forte</option>
                 <option value="agility">Agility</option>
                 <option value="speed">Speed</option>
+                <option value="custom1">Custom Attribute 1</option>
+                <option value="custom2">Custom Attribute 2</option>
             </select>
             <select name="skillRoot2" value="">
                 <option value=""></option>
@@ -171,6 +173,8 @@
                 <option value="forte">Forte</option>
                 <option value="agility">Agility</option>
                 <option value="speed">Speed</option>
+                <option value="custom1">Custom Attribute 1</option>
+                <option value="custom2">Custom Attribute 2</option>
             </select>
             <input type="checkbox" name="skillRequired">
             <input type="checkbox" name="skillOpened">
@@ -267,7 +271,7 @@
                     <option value="G">G</option>
                     <option value="W">W</option>
                 </select>
-                <input type="number" class="exponent" name="custom1Stat" value="1" min="1">
+                <input type="number" class="exponent" name="custom1Spent" value="1" min="1">
             </div>
             <div class="rules-text">
                 Some characters gain access to emotional attributes. Faith, Greed, Grief, Hatred, etc.
@@ -280,7 +284,7 @@
                     <option value="G">G</option>
                     <option value="W">W</option>
                 </select>
-                <input type="number" class="exponent" name="custom2Stat" value="1" min="1">
+                <input type="number" class="exponent" name="custom2Spent" value="1" min="1">
             </div>
             <div class="rules-text">
             </div>


### PR DESCRIPTION
Allows skills to root their abilities off of emotional attributes.
Since those can be placed in either custom1 or custom2 attributes, these skills would have to specify which attribute they are based off of indirectly until they are added to the character sheet.

Resolves #230 - Orc skills rooted in hatred.