### PR TITLE
Fight! style overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IDE
 .idea/
 .vs/
+.vscode/
 
 # Node Modules
 node_modules/

--- a/module/burningwheel.ts
+++ b/module/burningwheel.ts
@@ -1,7 +1,6 @@
 import { BWActor } from "./actors/BWActor.js";
 import { BWCharacterSheet } from "./actors/sheets/BWCharacterSheet.js";
 import { RegisterItemSheets } from "./items/item.js";
-import { ParticipantEntry } from "./dialogs/FightDialog.js";
 
 import { hideChatButtonsIfNotOwner, onChatLogRender } from "./chat.js";
 import { ShadeString, slugify, translateWoundValue } from "./helpers.js";
@@ -139,12 +138,6 @@ function registerHelpers() {
     Handlebars.registerHelper("clampWound", (shade: ShadeString, value: string | number): string => {
         return translateWoundValue(shade, value);
     });
-
-    Handlebars.registerHelper("getParticipantWeapon", (participant: ParticipantEntry): string => {
-        if (participant.weapons){
-            return participant.weapons.find(x => x.id === participant.weaponId)?.label ?? "";
-        } else {return "";}
-      });
 }
 
 

--- a/module/burningwheel.ts
+++ b/module/burningwheel.ts
@@ -1,6 +1,7 @@
 import { BWActor } from "./actors/BWActor.js";
 import { BWCharacterSheet } from "./actors/sheets/BWCharacterSheet.js";
 import { RegisterItemSheets } from "./items/item.js";
+import { ParticipantEntry } from "./dialogs/FightDialog.js";
 
 import { hideChatButtonsIfNotOwner, onChatLogRender } from "./chat.js";
 import { ShadeString, slugify, translateWoundValue } from "./helpers.js";
@@ -138,6 +139,12 @@ function registerHelpers() {
     Handlebars.registerHelper("clampWound", (shade: ShadeString, value: string | number): string => {
         return translateWoundValue(shade, value);
     });
+
+    Handlebars.registerHelper("getParticipantWeapon", (participant: ParticipantEntry): string => {
+        if (participant.weapons){
+            return participant.weapons.find(x => x.id === participant.weaponId)?.label ?? "";
+        } else {return "";}
+      });
 }
 
 

--- a/module/dialogs/FightDialog.ts
+++ b/module/dialogs/FightDialog.ts
@@ -253,7 +253,7 @@ export interface FightDialogData {
     showV3: boolean;
 }
 
-interface ParticipantEntry {
+export interface ParticipantEntry {
     showAction3: boolean;
     showAction2: boolean;
     showAction5: boolean;

--- a/module/dialogs/FightDialog.ts
+++ b/module/dialogs/FightDialog.ts
@@ -114,7 +114,7 @@ export class FightDialog extends ExtendedTestDialog<FightDialogData> {
         });
         html.find('.fighters-grid input, .fighters-grid select').on('change', (e: JQuery.ChangeEvent) => this.updateCollection(e, this.data.data.participants));
         ["Speed", "Power", "Agility", "Skill", "Steel"].forEach((attr: string) => {
-            html.find('button[data-action="roll'+attr+'"]')
+            html.find(`button[data-action="roll${attr}"]`)
                 .on('click', (e: JQuery.ClickEvent) => { this._handleRoll(e, attr.toLowerCase() as FightAttr); });
         });
         html.find('div[data-action="openSheet"], img[data-action="openSheet"]').on('click', (e: JQuery.ClickEvent) => {

--- a/module/dialogs/FightDialog.ts
+++ b/module/dialogs/FightDialog.ts
@@ -117,12 +117,10 @@ export class FightDialog extends ExtendedTestDialog<FightDialogData> {
             html.find('button[data-action="roll'+attr+'"]')
                 .on('click', (e: JQuery.ClickEvent) => { this._handleRoll(e, attr.toLowerCase() as FightAttr); });
         });
-        const openSheet = (e: JQuery.ClickEvent) => {
+        html.find('div[data-action="openSheet"], img[data-action="openSheet"]').on('click', (e: JQuery.ClickEvent) => {
             const id = e.currentTarget.attributes.getNamedItem("data-actor-id").nodeValue || "";
             game.actors.find(a => a._id === id).sheet.render(true);
-        };
-        html.find('img[data-action="openSheet"]').on('click', openSheet);
-        html.find('div[data-action="openSheet"]').on('click', openSheet);
+        });
     }
     
     private _handleRoll(e: JQuery.ClickEvent, type: FightAttr) {

--- a/module/rolls/fightRoll.ts
+++ b/module/rolls/fightRoll.ts
@@ -13,6 +13,8 @@ import { MeleeWeapon } from "../items/meleeWeapon.js";
 import { RangedWeapon } from "../items/rangedWeapon.js";
 import { Skill } from "../items/skill.js";
 import { Spell } from "../items/spell.js";
+import { handleAttrRoll } from "./rollAttribute.js";
+import { FightAttr } from "../dialogs/index.js";
 
 export async function handleFightRoll({actor, type, itemId, attackIndex, positionPenalty, engagementBonus, dataPreset }: FightRollOptions): Promise<unknown> {
     dataPreset = dataPreset || {};
@@ -95,6 +97,17 @@ export async function handleFightRoll({actor, type, itemId, attackIndex, positio
     }
     const accessor = `data.${type}`;
     const stat = getProperty(actor, `data.${accessor}`) as Ability;
+
+    if (type === "steel"){
+        return handleAttrRoll({
+            actor: actor as BWCharacter,
+            stat: actor.data.data.steel,
+            attrName: "Steel",
+            accessor,
+            dataPreset
+        });
+    }
+    
     return handleStatRoll({
         actor: actor as BWCharacter,
         statName: type.titleCase(),
@@ -106,7 +119,7 @@ export async function handleFightRoll({actor, type, itemId, attackIndex, positio
 
 export interface FightRollOptions {
     actor: BWActor,
-    type: "speed" | "agility" | "power" | "skill",
+    type: FightAttr,
     itemId?: string;
     attackIndex?: number;
     engagementBonus: number;

--- a/styles/dialog/fight.scss
+++ b/styles/dialog/fight.scss
@@ -23,6 +23,7 @@
         display: grid;
         width: 100%;
         height: min-content;
+        overflow: hidden;
         grid-template-columns: repeat(4, 1fr);
         margin: 1em 0 1em 0;
 
@@ -41,6 +42,7 @@
                 height: 26px;
                 text-align: left;
                 overflow: hidden;
+                white-space: nowrap;
             }
             
             .exponent {
@@ -49,10 +51,6 @@
                 height: 22px;
             }
 
-            .pick-weapon{
-                height: 22px;
-            }
-            
             .withLabels{
                 display: flex;
                 flex-direction: row-reverse;
@@ -62,6 +60,7 @@
                     padding-top: 2px;
                 }
                 .exponent-meaning {
+                    flex-direction: row;
                     padding-top: 4px;
                 }
             }

--- a/styles/dialog/fight.scss
+++ b/styles/dialog/fight.scss
@@ -22,15 +22,15 @@
     .details {
         display: grid;
         grid-template-columns: repeat(4, 1fr);
-        border: 2px groove #aaaaaa;
         justify-items: stretch;
         column-gap: 2px;
         row-gap: 2px;
+        width: 100%;
         .details-key{
             display: flex;
             align-items: center;
             background: rgba(#000, .03);
-            border: 2px groove #aaaaaa;
+            border: 1px groove #f0f0f0;
             padding: 1px;
         }
         .details-value{
@@ -39,8 +39,8 @@
             flex-direction: row-reverse;
             justify-content: end;
             text-align: end;
-            background: rgba(#444, .25);
-            border: 2px groove #aaaaaa;
+            background: rgba(#000, .1);
+            border: 1px groove #f0f0f0;
             text-align: end;
             padding: 1px;
         }
@@ -48,9 +48,10 @@
     .weapon-block {
         display: grid;
         align-items: center;
+        width: 100%;
         padding: 5px 5px 0 5px;
         //Weapon word has static width
-        grid-template-columns: [line1] 50px [line2] auto [col2-start];
+        grid-template-columns: 50px 1fr;
         justify-content: stretch;
         .weapon-picker {
             justify-self: end;
@@ -65,13 +66,11 @@
         grid-template-columns: repeat(4, 1fr);
         margin: 1em 0 1em 0;
 
-        .pill-toggle{
-            & > input[type="checkbox"]{
-                &:checked + label {
-                    background: linear-gradient(rgb(238, 230, 126), rgb(170, 159, 0));
-                    border: 2px solid #880000;
-                    color: #880000;
-        }}}
+        .pill-toggle > input[type="checkbox"]:checked + label {
+            background: linear-gradient(rgb(238, 230, 126), rgb(170, 159, 0));
+            border: 2px solid #880000;
+            color: #880000;
+        }
 
         .fighters-label{
             width: 100%;
@@ -81,11 +80,16 @@
 
         .portrait {
             width: 120px; height: 120px;
+            border: 0px;
             object-fit: cover;
         }
 
         .pill-toggle > label {
             border-radius: 0;
+        }
+
+        .gm-overview{
+            width: 100%;
         }
 
         .volley-buttons {
@@ -98,8 +102,6 @@
             .portrait-actions {
                 flex-grow: 1;
                 display: flex;
-                //justify-content: center;
-                //align-items: center;
                 .fight-rolls {
                     flex-grow: 1;
                     display: flex;
@@ -107,10 +109,8 @@
                     flex-direction: column;
                     justify-content: center;
                     align-items: center;
-                    overflow: hidden;
                     max-height: 130px;
                     .control-button {
-                        overflow: hidden;
                         width: 49%;
                     }
                 }
@@ -182,28 +182,24 @@
                 border-radius: 3px;
             }
      
-            .fighter-action-panel {
+            .remove-fighter {
+                width: 1.5em;
+                height: 1.5em;
+                padding: 1px;
+                line-height: 1.3em;
+                color: #800;
+            }
+            .actor-name {
                 display: flex;
-                flex-direction: row;
-                .remove-fighter {
-                    width: 1.5em;
-                    height: 1.5em;
-                    padding: 1px;
-                    line-height: 1.3em;
+                justify-content: center;
+                align-items: center;
+                font-size: 1.125em;
+                font-weight: bold;
+                flex-grow: 1;
+                padding-right: 1.5em;
+                width: calc(100% - 1.5em);
+                &:hover {
                     color: #800;
-                }
-                .actor-name {
-                    display: flex;
-                    justify-content: center;
-                    align-items: center;
-                    font-size: 1.125em;
-                    font-weight: bold;
-                    flex-grow: 1;
-                    padding-right: 1.5em;
-                    width: calc(100% - 1.5em);
-                    &:hover {
-                        color: #800;
-                    }
                 }
             }
         }
@@ -224,9 +220,5 @@
                 width: 100%;
             }
         }
-    }
-    .gm-overview {
-        display: flex;
-        flex-direction: column;
     }
 }

--- a/styles/dialog/fight.scss
+++ b/styles/dialog/fight.scss
@@ -7,9 +7,9 @@
     }
 
     .control-grid {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        column-gap: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         width: 100%;
         height: min-content;
         .control-button {
@@ -26,6 +26,54 @@
         grid-template-columns: repeat(4, 1fr);
         margin: 1em 0 1em 0;
 
+        .portrait {
+            width: 130px; height: 130px;
+            border: 2px solid #880000;
+            object-fit: cover;
+        }
+
+        .details {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-grow: 1;
+            td {
+                height: 26px;
+                text-align: left;
+                overflow: hidden;
+            }
+            
+            .exponent {
+                text-align: right;
+                width: 22px;
+                height: 22px;
+            }
+
+            .pick-weapon{
+                height: 22px;
+            }
+            
+            .withLabels{
+                display: flex;
+                flex-direction: row-reverse;
+                div {
+                    display: flex;
+                    flex-direction: column;
+                    padding-top: 2px;
+                }
+                .exponent-meaning {
+                    padding-top: 4px;
+                }
+            }
+        }
+
+        .portrait-actions{
+            flex-grow: 1;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
         .pill-toggle > label {
             border-radius: 0;
         }
@@ -38,7 +86,7 @@
                 padding-left: 5px;
             }
             .control-button {
-                width: 49%;
+                width: 100%;
                 height: min-content;
             }
         }
@@ -47,7 +95,12 @@
             border: 2px groove #aaaaaa;
             background: linear-gradient(rgba(#444, .25), rgba(#000, .05));
             min-height: 1.5em;
+            text-align: center;
+            display: flex;
+            align-items: center;
+            justify-content: center; 
             margin: 0;
+            padding: 2px;
 
             .attack-action {
                 -webkit-hyphens: auto;
@@ -92,6 +145,7 @@
         .participant-card {
             width: 100%;
             display: flex;
+            flex-direction: column;
             flex-wrap: wrap;
 
             .control-button {
@@ -102,36 +156,73 @@
                 border-radius: 3px;
             }
 
-            .remove-fighter {
-                width: 1.5em;
-                height: 1.5em;
-                padding: 1px;
-                line-height: 1.3em;
-                color: #800;
+            .exponent {
+                text-align: right;
+                width: 22px;
+                height: 22px;
             }
 
-            .actor-name {
-                font-size: 1.125em;
-                font-weight: bold;
-                width: calc(100% - 1.5em);
-                &:hover {
-                    color: #800;
+            .pick-weapon{
+                height: 22px;
+            }
+            
+            .withLabels{
+                display: flex;
+                flex-direction: row-reverse;
+                div {
+                    display: flex;
+                    flex-direction: column;
+                    padding-top: 2px;
+                }
+                .exponent-meaning {
+                    padding-top: 4px;
                 }
             }
-            .portrait {
-                width: 80px; height: 80px;
-                border: 0;
-                object-fit: cover;
+
+            .fighter-action-panel{
+                display: flex;
+                flex-direction: row;
+                position: relative;
+                flex-grow: 1;
+                .remove-fighter {
+                    position: absolute;
+                    width: 1.5em;
+                    height: 1.5em;
+                    padding: 1px;
+                    line-height: 1.3em;
+                    color: #800;
+                }
+                .actor-name {
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    font-size: 1.125em;
+                    font-weight: bold;
+                    flex-grow: 1;
+                    width: calc(100% - 1.5em);
+                    &:hover {
+                        color: #800;
+                    }
+                }
             }
+
             .details {
-                width: calc(95% - 80px);
-                margin-left: 2%;
-                select {
-                    width: 100%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                flex-grow: 1;
+                td {
+                    height: 26px;
+                    overflow: hidden;
                 }
             }
         }
+
         .volley {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
             label {
                 display: block;
             }

--- a/styles/dialog/fight.scss
+++ b/styles/dialog/fight.scss
@@ -19,58 +19,69 @@
         }
     }
 
+    .details {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        border: 2px groove #aaaaaa;
+        justify-items: stretch;
+        column-gap: 2px;
+        row-gap: 2px;
+        .details-key{
+            display: flex;
+            align-items: center;
+            background: rgba(#000, .03);
+            border: 2px groove #aaaaaa;
+            padding: 1px;
+        }
+        .details-value{
+            display: flex;
+            align-items: center;
+            flex-direction: row-reverse;
+            justify-content: end;
+            text-align: end;
+            background: rgba(#444, .25);
+            border: 2px groove #aaaaaa;
+            text-align: end;
+            padding: 1px;
+        }
+    }
+    .weapon-block {
+        display: grid;
+        align-items: center;
+        padding: 5px 5px 0 5px;
+        //Weapon word has static width
+        grid-template-columns: [line1] 50px [line2] auto [col2-start];
+        justify-content: stretch;
+        .weapon-picker {
+            justify-self: end;
+            grid-column-start: 2;
+        }
+    }
+
     .volley-description {
         display: grid;
         width: 100%;
         height: min-content;
-        overflow: hidden;
         grid-template-columns: repeat(4, 1fr);
         margin: 1em 0 1em 0;
 
+        .pill-toggle{
+            & > input[type="checkbox"]{
+                &:checked + label {
+                    background: linear-gradient(rgb(238, 230, 126), rgb(170, 159, 0));
+                    border: 2px solid #880000;
+                    color: #880000;
+        }}}
+
+        .fighters-label{
+            width: 100%;
+            font-size: 1.25em;
+            font-weight: bold;
+        }
+
         .portrait {
-            width: 130px; height: 130px;
-            border: 2px solid #880000;
+            width: 120px; height: 120px;
             object-fit: cover;
-        }
-
-        .details {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            flex-grow: 1;
-            td {
-                height: 26px;
-                text-align: left;
-                overflow: hidden;
-                white-space: nowrap;
-            }
-            
-            .exponent {
-                text-align: right;
-                width: 22px;
-                height: 22px;
-            }
-
-            .withLabels{
-                display: flex;
-                flex-direction: row-reverse;
-                div {
-                    display: flex;
-                    flex-direction: column;
-                    padding-top: 2px;
-                }
-                .exponent-meaning {
-                    flex-direction: row;
-                    padding-top: 4px;
-                }
-            }
-        }
-
-        .portrait-actions{
-            flex-grow: 1;
-            display: flex;
-            justify-content: center;
-            align-items: center;
         }
 
         .pill-toggle > label {
@@ -84,9 +95,25 @@
                 font-weight: bold;
                 padding-left: 5px;
             }
-            .control-button {
-                width: 100%;
-                height: min-content;
+            .portrait-actions {
+                flex-grow: 1;
+                display: flex;
+                //justify-content: center;
+                //align-items: center;
+                .fight-rolls {
+                    flex-grow: 1;
+                    display: flex;
+                    flex-wrap: wrap;
+                    flex-direction: column;
+                    justify-content: center;
+                    align-items: center;
+                    overflow: hidden;
+                    max-height: 130px;
+                    .control-button {
+                        overflow: hidden;
+                        width: 49%;
+                    }
+                }
             }
         }
 
@@ -154,37 +181,11 @@
                 color: black;
                 border-radius: 3px;
             }
-
-            .exponent {
-                text-align: right;
-                width: 22px;
-                height: 22px;
-            }
-
-            .pick-weapon{
-                height: 22px;
-            }
-            
-            .withLabels{
-                display: flex;
-                flex-direction: row-reverse;
-                div {
-                    display: flex;
-                    flex-direction: column;
-                    padding-top: 2px;
-                }
-                .exponent-meaning {
-                    padding-top: 4px;
-                }
-            }
-
-            .fighter-action-panel{
+     
+            .fighter-action-panel {
                 display: flex;
                 flex-direction: row;
-                position: relative;
-                flex-grow: 1;
                 .remove-fighter {
-                    position: absolute;
                     width: 1.5em;
                     height: 1.5em;
                     padding: 1px;
@@ -198,21 +199,11 @@
                     font-size: 1.125em;
                     font-weight: bold;
                     flex-grow: 1;
+                    padding-right: 1.5em;
                     width: calc(100% - 1.5em);
                     &:hover {
                         color: #800;
                     }
-                }
-            }
-
-            .details {
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                flex-grow: 1;
-                td {
-                    height: 26px;
-                    overflow: hidden;
                 }
             }
         }
@@ -233,5 +224,9 @@
                 width: 100%;
             }
         }
+    }
+    .gm-overview {
+        display: flex;
+        flex-direction: column;
     }
 }

--- a/templates/dialogs/fight.hbs
+++ b/templates/dialogs/fight.hbs
@@ -45,30 +45,19 @@
                         <tr>
                             <td>Engagement</td>
                             <td class="withLabels">
-                                <div class="exponent-meaning">D</div>
-                                <input data-index="{{i}}" name="engagementBonus" type="number" class="exponent" value="{{p.engagementBonus}}">
-                                <div>+</div>
+                                <div class="exponent-meaning">+{{p.engagementBonus}}D</div>
                             </td>
                         </tr>
                         <tr>
                             <td>Position</td>
                             <td class="withLabels">
-                                <div class="exponent-meaning">Ob</div>
-                                <input data-index="{{i}}" name="positionPenalty" type="number" class="exponent" value="{{p.positionPenalty}}">
-                                <div>+</div>
+                                <div class="exponent-meaning">+{{p.positionPenalty}}Ob</div>
                             </td>
                         </tr>
                         <tr>
                             <td>Weapon</td>
                             <td>
-                                <select class="pick-weapon" data-index="{{i}}" name="weaponId">
-                                {{#select p.weaponId}}
-                                <option value="">Pick a Weapon</option>
-                                {{#each p.weapons as |s|}}
-                                <option value="{{s.id}}">{{s.label}}</option>
-                                {{/each}}
-                                {{/select}}
-                                </select>
+                                <div class="exponent-meaning">{{#getParticipantWeapon p}}{{/getParticipantWeapon}}</div>
                             </td>
                         </tr>
                     </table>

--- a/templates/dialogs/fight.hbs
+++ b/templates/dialogs/fight.hbs
@@ -7,7 +7,7 @@
     {{/if}}
     <div class="volley-description">
         {{#if gmView}}
-        <div><h3><strong>Fighters</strong></h3></div>
+        <div class="fighters-label">Fighters</div>
         <div class="pill-toggle">
             <input type="checkbox" name="showV1" id="showFightV1" {{checked showV1}}>
             <label for="showFightV1">Show Volley 1</label>
@@ -21,47 +21,45 @@
             <label for="showFightV3">Show Volley 3</label>
         </div>
         {{else}}
-        <div><h3><strong>Fighters</strong></h3></div><div>Volley 1</div><div>Volley 2</div><div>Volley 3</div>
+        <div class="fighters-label">Fighters</div><div>Volley 1</div><div>Volley 2</div><div>Volley 3</div>
         {{/if}}
         {{#each participants as |p i|}}
         <div class="volley-buttons flex-row">
             <div class="participant">{{p.name}}</div>
             <div class="portrait-actions">
                 {{#if p.showActions}}
-                <img class="portrait clickable" src="{{p.imgSrc}}" title="{{p.name}}" data-action="openSheet" data-actor-id="{{p.id}}"/>
-                <div>
-                    <button class="control-button" data-index="{{i}}" data-action="rollSpeed">Speed</button>
-                    <button class="control-button" data-index="{{i}}" data-action="rollPower">Power</button>
-                    <button class="control-button" data-index="{{i}}" data-action="rollAgility">Agility</button>
-                    <button class="control-button" data-index="{{i}}" data-action="rollSkill">Skill</button>
-                </div>
+                    <img class="portrait clickable" src="{{p.imgSrc}}" title="{{p.name}}" data-action="openSheet" data-actor-id="{{p.id}}"/>
+                    <div class="fight-rolls">
+                        <button class="control-button" data-index="{{i}}" data-action="rollSpeed">Speed</button>
+                        <button class="control-button" data-index="{{i}}" data-action="rollPower">Power</button>
+                        <button class="control-button" data-index="{{i}}" data-action="rollAgility">Agility</button>
+                        <button class="control-button" data-index="{{i}}" data-action="rollSkill">Skill</button>
+                        <button class="control-button" data-index="{{i}}" data-action="rollSteel">Steel</button>
+                    </div>
                 {{else}}
-                <div class="details">
-                    <table>
-                        <tr>
-                            <td>Reflexes</td> 
-                            <td class="exponent">{{p.reflexes}}</td>
-                        </tr>
-                        <tr>
-                            <td>Engagement</td>
-                            <td class="withLabels">
-                                <div class="exponent-meaning">+{{p.engagementBonus}}D</div>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Position</td>
-                            <td class="withLabels">
-                                <div class="exponent-meaning">+{{p.positionPenalty}}Ob</div>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Weapon</td>
-                            <td>
-                                <div class="exponent-meaning">{{#getParticipantWeapon p}}{{/getParticipantWeapon}}</div>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
+                    {{#if ../gmView}}
+                        <div class="gm-overview">
+                        <div class="details clickable" data-action="openSheet" title="{{p.name}}" data-actor-id="{{p.id}}">
+                                <div class="details-key">Reflexes</div> 
+                                <div class="details-value">{{p.reflexes}}</div>
+                                <div class="details-key">Engagement</div>
+                                <div class="details-value">
+                                    <div style="width: 7px;"></div>
+                                    <div>+{{p.engagementBonus}}D</div>
+                                </div>
+                                <div class="details-key">Position</div>
+                                <div class="details-value">
+                                    <div class=>+{{p.positionPenalty}}Ob</div>
+                                </div>
+                        </div>
+                        <div class="weapon-block">
+                            <div>Weapon</div>
+                            <div class="weapon-picker">{{p.chosenWeaponLabel}}</div>
+                        </div>
+                        </div>
+                    {{else}}
+                        <img class="portrait" src="{{p.imgSrc}}" title="{{p.name}}"/>
+                    {{/if}}
                 {{/if}}
             </div>
         </div>
@@ -114,41 +112,33 @@
             </div>
             {{#if p.showActions}}
             <div class="details">
-                <table>
-                    <tr>
-                        <td>Reflexes</td> 
-                        <td class="exponent">{{p.reflexes}}</td>
-                    </tr>
-                    <tr>
-                        <td>Engagement</td>
-                        <td class="withLabels">
-                            <div class="exponent-meaning">D</div>
-                            <input data-index="{{i}}" name="engagementBonus" type="number" class="exponent" value="{{p.engagementBonus}}">
-                            <div>+</div>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Position</td>
-                        <td class="withLabels">
-                            <div class="exponent-meaning">Ob</div>
-                            <input data-index="{{i}}" name="positionPenalty" type="number" class="exponent" value="{{p.positionPenalty}}">
-                            <div>+</div>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>Weapon</td>
-                        <td>
-                            <select class="pick-weapon" data-index="{{i}}" name="weaponId">
-                            {{#select p.weaponId}}
+                <div class="details-key">Reflexes</div>
+                <div class="details-value">{{p.reflexes}}</div>
+                <div class="details-key">Engagement</div>
+                <div class="withLabels details-value">
+                    <div class="exponent-meaning">D</div>
+                    <input data-index="{{i}}" name="engagementBonus" type="number" class="exponent" value="{{p.engagementBonus}}">
+                    <div>+</div>
+                </div>
+                <div class="details-key">Position</div>
+                <div class="withLabels details-value">
+                    <div class="exponent-meaning">Ob</div>
+                    <input data-index="{{i}}" name="positionPenalty" type="number" class="exponent" value="{{p.positionPenalty}}">
+                    <div>+</div>
+                </div>
+            </div>
+            <div class="weapon-block">
+                <div>Weapon</div>
+                <div class="weapon-picker">
+                    <select data-index="{{i}}" name="weaponId">
+                        {{#select p.weaponId}}
                             <option value="">Pick a Weapon</option>
                             {{#each p.weapons as |s|}}
-                            <option value="{{s.id}}">{{s.label}}</option>
+                                <option value="{{s.id}}">{{s.label}}</option>
                             {{/each}}
-                            {{/select}}
-                            </select>
-                        </td>
-                    </tr>
-                </table>
+                        {{/select}}
+                    </select>
+                </div>
             </div>
             {{/if}}
         </div>

--- a/templates/dialogs/fight.hbs
+++ b/templates/dialogs/fight.hbs
@@ -7,7 +7,7 @@
     {{/if}}
     <div class="volley-description">
         {{#if gmView}}
-        <div>Fighters</div>
+        <div><h3><strong>Fighters</strong></h3></div>
         <div class="pill-toggle">
             <input type="checkbox" name="showV1" id="showFightV1" {{checked showV1}}>
             <label for="showFightV1">Show Volley 1</label>
@@ -21,17 +21,60 @@
             <label for="showFightV3">Show Volley 3</label>
         </div>
         {{else}}
-        <div>Fighters</div><div>Volley 1</div><div>Volley 2</div><div>Volley 3</div>
+        <div><h3><strong>Fighters</strong></h3></div><div>Volley 1</div><div>Volley 2</div><div>Volley 3</div>
         {{/if}}
         {{#each participants as |p i|}}
         <div class="volley-buttons flex-row">
             <div class="participant">{{p.name}}</div>
-            {{#if p.showActions}}
-            <button class="control-button" data-index="{{i}}" data-action="rollSpeed">Test Speed</button>
-            <button class="control-button" data-index="{{i}}" data-action="rollPower">Test Power</button>
-            <button class="control-button" data-index="{{i}}" data-action="rollAgility">Test Agility</button>
-            <button class="control-button" data-index="{{i}}" data-action="rollSkill">Test Skill</button>
-            {{/if}}
+            <div class="portrait-actions">
+                {{#if p.showActions}}
+                <img class="portrait clickable" src="{{p.imgSrc}}" title="{{p.name}}" data-action="openSheet" data-actor-id="{{p.id}}"/>
+                <div>
+                    <button class="control-button" data-index="{{i}}" data-action="rollSpeed">Speed</button>
+                    <button class="control-button" data-index="{{i}}" data-action="rollPower">Power</button>
+                    <button class="control-button" data-index="{{i}}" data-action="rollAgility">Agility</button>
+                    <button class="control-button" data-index="{{i}}" data-action="rollSkill">Skill</button>
+                </div>
+                {{else}}
+                <div class="details">
+                    <table>
+                        <tr>
+                            <td>Reflexes</td> 
+                            <td class="exponent">{{p.reflexes}}</td>
+                        </tr>
+                        <tr>
+                            <td>Engagement</td>
+                            <td class="withLabels">
+                                <div class="exponent-meaning">D</div>
+                                <input data-index="{{i}}" name="engagementBonus" type="number" class="exponent" value="{{p.engagementBonus}}">
+                                <div>+</div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Position</td>
+                            <td class="withLabels">
+                                <div class="exponent-meaning">Ob</div>
+                                <input data-index="{{i}}" name="positionPenalty" type="number" class="exponent" value="{{p.positionPenalty}}">
+                                <div>+</div>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Weapon</td>
+                            <td>
+                                <select class="pick-weapon" data-index="{{i}}" name="weaponId">
+                                {{#select p.weaponId}}
+                                <option value="">Pick a Weapon</option>
+                                {{#each p.weapons as |s|}}
+                                <option value="{{s.id}}">{{s.label}}</option>
+                                {{/each}}
+                                {{/select}}
+                                </select>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                {{/if}}
+            </div>
         </div>
         <div class="flex-row" lang="en">
             {{#if ../showV1}}
@@ -60,7 +103,7 @@
         {{/each}}
     </div>
     <div class="fighters-grid">
-        <div class="participant-card">
+        <div class="participant-card volley">
             Participant
         </div>
         <div class="volley">
@@ -74,35 +117,49 @@
         </div>
         {{#each participants as |p i|}}
         <div class="participant-card">
-            {{#if ../gmView}}
-            <i data-action="removeFighter" data-index="{{i}}" class="fas fa-times remove-fighter"></i>
-            {{/if}}
-            <div class="actor-name clickable" data-action="toggleHidden" data-index="{{i}}">{{p.name}}</div>
+            <div class="fighter-action-panel">
+                {{#if ../gmView}}
+                <i data-action="removeFighter" data-index="{{i}}" class="fas fa-times remove-fighter"></i>
+                {{/if}}
+                <div class="actor-name clickable" data-action="toggleHidden" data-index="{{i}}">{{p.name}}</div>
+            </div>
             {{#if p.showActions}}
-            <img class="portrait clickable" src="{{p.imgSrc}}" title="{{p.name}}" data-action="openSheet" data-actor-id="{{p.id}}"/>
             <div class="details">
-                <div>
-                    Reflexes: {{p.reflexes}}
-                </div>
-                <div>
-                    Engagement Bonus
-                    <input data-index="{{i}}" name="engagementBonus" type="number" class="exponent no-arrows" value="{{p.engagementBonus}}">
-                </div>
-                <div>
-                    Position Penalty
-                    <input data-index="{{i}}" name="positionPenalty" type="number" class="exponent no-arrows" value="{{p.positionPenalty}}">
-                </div>
-                <div>
-                    Active Weapon
-                    <select data-index="{{i}}" name="weaponId">
-                        {{#select p.weaponId}}
-                        <option value="">Pick a Weapon</option>
-                        {{#each p.weapons as |s|}}
-                        <option value="{{s.id}}">{{s.label}}</option>
-                        {{/each}}
-                        {{/select}}
-                    </select>
-                </div>
+                <table>
+                    <tr>
+                        <td>Reflexes</td> 
+                        <td class="exponent">{{p.reflexes}}</td>
+                    </tr>
+                    <tr>
+                        <td>Engagement</td>
+                        <td class="withLabels">
+                            <div class="exponent-meaning">D</div>
+                            <input data-index="{{i}}" name="engagementBonus" type="number" class="exponent" value="{{p.engagementBonus}}">
+                            <div>+</div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Position</td>
+                        <td class="withLabels">
+                            <div class="exponent-meaning">Ob</div>
+                            <input data-index="{{i}}" name="positionPenalty" type="number" class="exponent" value="{{p.positionPenalty}}">
+                            <div>+</div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>Weapon</td>
+                        <td>
+                            <select class="pick-weapon" data-index="{{i}}" name="weaponId">
+                            {{#select p.weaponId}}
+                            <option value="">Pick a Weapon</option>
+                            {{#each p.weapons as |s|}}
+                            <option value="{{s.id}}">{{s.label}}</option>
+                            {{/each}}
+                            {{/select}}
+                            </select>
+                        </td>
+                    </tr>
+                </table>
             </div>
             {{/if}}
         </div>

--- a/templates/dialogs/fight.hbs
+++ b/templates/dialogs/fight.hbs
@@ -39,23 +39,23 @@
                 {{else}}
                     {{#if ../gmView}}
                         <div class="gm-overview">
-                        <div class="details clickable" data-action="openSheet" title="{{p.name}}" data-actor-id="{{p.id}}">
-                                <div class="details-key">Reflexes</div> 
-                                <div class="details-value">{{p.reflexes}}</div>
-                                <div class="details-key">Engagement</div>
-                                <div class="details-value">
-                                    <div style="width: 7px;"></div>
-                                    <div>+{{p.engagementBonus}}D</div>
-                                </div>
-                                <div class="details-key">Position</div>
-                                <div class="details-value">
-                                    <div class=>+{{p.positionPenalty}}Ob</div>
-                                </div>
-                        </div>
-                        <div class="weapon-block">
-                            <div>Weapon</div>
-                            <div class="weapon-picker">{{p.chosenWeaponLabel}}</div>
-                        </div>
+                            <div class="details clickable" data-action="openSheet" title="{{p.name}}" data-actor-id="{{p.id}}">
+                                    <div class="details-key">Reflexes</div> 
+                                    <div class="details-value">{{p.reflexes}}</div>
+                                    <div class="details-key">Engagement</div>
+                                    <div class="details-value">
+                                        <div style="width: 7px;"></div>
+                                        <div>+{{p.engagementBonus}}D</div>
+                                    </div>
+                                    <div class="details-key">Position</div>
+                                    <div class="details-value">
+                                        <div class=>+{{p.positionPenalty}}Ob</div>
+                                    </div>
+                            </div>
+                            <div class="weapon-block">
+                                <div>Weapon</div>
+                                <div class="weapon-picker">{{p.chosenWeaponLabel}}</div>
+                            </div>
                         </div>
                     {{else}}
                         <img class="portrait" src="{{p.imgSrc}}" title="{{p.name}}"/>
@@ -104,25 +104,27 @@
         </div>
         {{#each participants as |p i|}}
         <div class="participant-card">
-            <div class="fighter-action-panel">
+            <div class="fighter-action-panel flex-row">
                 {{#if ../gmView}}
                 <i data-action="removeFighter" data-index="{{i}}" class="fas fa-times remove-fighter"></i>
+                {{else}}
+                <div style="padding-left: 1.5em;"></div>
                 {{/if}}
-                <div class="actor-name clickable" data-action="toggleHidden" data-index="{{i}}">{{p.name}}</div>
+                <div class="actor-name clickable flex-row" data-action="toggleHidden" data-index="{{i}}">{{p.name}}</div>
             </div>
             {{#if p.showActions}}
             <div class="details">
                 <div class="details-key">Reflexes</div>
                 <div class="details-value">{{p.reflexes}}</div>
                 <div class="details-key">Engagement</div>
-                <div class="withLabels details-value">
-                    <div class="exponent-meaning">D</div>
+                <div class="details-value">
+                    <div>D</div>
                     <input data-index="{{i}}" name="engagementBonus" type="number" class="exponent" value="{{p.engagementBonus}}">
                     <div>+</div>
                 </div>
                 <div class="details-key">Position</div>
-                <div class="withLabels details-value">
-                    <div class="exponent-meaning">Ob</div>
+                <div class="details-value">
+                    <div>Ob</div>
                     <input data-index="{{i}}" name="positionPenalty" type="number" class="exponent" value="{{p.positionPenalty}}">
                     <div>+</div>
                 </div>
@@ -132,10 +134,10 @@
                 <div class="weapon-picker">
                     <select data-index="{{i}}" name="weaponId">
                         {{#select p.weaponId}}
-                            <option value="">Pick a Weapon</option>
-                            {{#each p.weapons as |s|}}
-                                <option value="{{s.id}}">{{s.label}}</option>
-                            {{/each}}
+                        <option value="">Pick a Weapon</option>
+                        {{#each p.weapons as |s|}}
+                        <option value="{{s.id}}">{{s.label}}</option>
+                        {{/each}}
                         {{/select}}
                     </select>
                 </div>


### PR DESCRIPTION
##Changes
This PR overhauls the look of Fight! dialog window. It optimises space and structures information, allowing for further Fight! additions like wounds, stance, tax, 1vX penatly, size Lock penalty ect..
Most notable changes are:
- combatants details(positon, engagement ect.) are now structured as a table
- combatants portraits are moved to overview
- hiding combatants for GM means overview shows only details, but not portrait or roll buttons
- Steel attribute roll is included to overview panel
- most HTML elements are now treated as flex to promote reactive design and look nicer on small resolutions/window sizes
- overview is able to show larger portraits for both GM and players

Possible TODOs: several fight tabs with Eye of the storm! feature, "sides" tag on actors, auto volley resolution for sides

## Extra Info

Extra information for the fix is also quite helpful. Try to answer any relevant questions in the comment.
- [No] Did this PR have to change `template.yml`?
- [- ] If so, were there any steps taken to protect existing user data? A migration task?
- [X] Did you follow the [contributing guidelines](https://github.com/StasTserk/foundry-burningwheel/blob/master/CONTRIBUTING.md)?
- [No] Is this PR limited to fixing just one issue? Although there are several changes they all are related only to Fight! dialog restyle
