### PR TITLE
Negative stats from lifepaths

### DIFF
--- a/module/dialogs/CharacterBurnerDialog.ts
+++ b/module/dialogs/CharacterBurnerDialog.ts
@@ -326,17 +326,18 @@ export class CharacterBurnerDialog extends Dialog {
         
         const mentalPoints = emptyLifepath.nextAll('.inline-text').first().children('input[name="mentalStat"]').first();
         const physicalPoints = emptyLifepath.nextAll('.inline-text').first().next().children('input[name="physicalStat"]').first();
+        const boostAmount = pathData.subtractStats ? -1 : 1;
 
         switch (pathData.statBoost) {
             case "both":
-                mentalPoints.val(1).trigger('change');
-                physicalPoints.val(1).trigger('change');
+                mentalPoints.val(boostAmount).trigger('change');
+                physicalPoints.val(boostAmount).trigger('change');
                 break;
             case "mental":
-                mentalPoints.val(1).trigger('change');
+                mentalPoints.val(boostAmount).trigger('change');
                 break;
             case "physical":
-                physicalPoints.val(1).trigger('change');
+                physicalPoints.val(boostAmount).trigger('change');
                 break;
             case "either":
                 new Dialog({
@@ -345,11 +346,11 @@ export class CharacterBurnerDialog extends Dialog {
                     buttons: {
                         mental: {
                             label: "Assign to Mental",
-                            callback: () => { mentalPoints.val(1).trigger('change'); }
+                            callback: () => { mentalPoints.val(boostAmount).trigger('change'); }
                         },
                         physical: {
                             label: "Assign to Physical",
-                            callback: () => { physicalPoints.val(1).trigger('change'); }
+                            callback: () => { physicalPoints.val(boostAmount).trigger('change'); }
                         }
                     }
                 }).render(true);

--- a/module/items/lifepath.ts
+++ b/module/items/lifepath.ts
@@ -8,7 +8,8 @@ export class Lifepath extends BWItem {
 
     prepareData(): void {
         super.prepareData();
-        this.data.data.statString = statMap[this.data.data.statBoost];
+        const statSign = this.data.data.statBoost === "none" ? "" : (this.data.data.subtractStats ? "-" : "+");
+        this.data.data.statString = statSign + statMap[this.data.data.statBoost];
     }
 }
 
@@ -21,6 +22,7 @@ export interface LifepathData {
     time: number;
     resources: number;
     statBoost: 'none' | 'mental' | 'physical' | 'either' | 'both';
+    subtractStats: boolean;
     leads: string;
     skillPoints: number;
     generalPoints: number;
@@ -38,8 +40,8 @@ export interface LifepathData {
 
 const statMap = {
     "none": "&mdash;",
-    "mental": "+1 M",
-    "physical": "+1 P",
-    "either": "+1 M/P",
-    "both": "+1 M,P"
+    "mental": "1 M",
+    "physical": "1 P",
+    "either": "1 M/P",
+    "both": "1 M,P"
 };

--- a/system.json
+++ b/system.json
@@ -3,7 +3,7 @@
     "title": "The Burning Wheel",
     "description": "Community Foundry implementation of The Burning Wheel",
     "version": "1.0.1",
-    "templateVersion": 19,
+    "templateVersion": 20,
     "author": "Stas Tserkovny",
     "esmodules": [
         "module/burningwheel.js"

--- a/template.yml
+++ b/template.yml
@@ -363,6 +363,7 @@ Item:
     time: 5
     resources: 5
     statBoost: 'none'
+    subtractStats: false
     leads: 'Any'
     skillPoints: 0
     generalPoints: 0

--- a/templates/items/lifepath.hbs
+++ b/templates/items/lifepath.hbs
@@ -26,7 +26,11 @@
             <option value="both">Both</option>
             {{/select}}
         </select>
-        <div></div><div></div>
+        <div class="pill-toggle min-content">
+            <input id="{{item._id}}-sub-stats" type="checkbox" class="item-setting-checkbox hidden" name="data.subtractStats" {{checked data.subtractStats}}>
+            <label for="{{item._id}}-sub-stats" class="item-setting-toggle">Subtract Stats</label>
+        </div>
+        <div></div>
         <label class="item-setting-label">
             Leads
         </label>


### PR DESCRIPTION
Adds a negative stat toggle to the lifepath sheet which allows the lifepaths to subtract stats instead of adding them.

Resolves #318