### PR TITLE
Cleaner FPD near beliefs and instincts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contributing Guidelines
 
-With the system going into a more passive bugfixing and maintane mode with the release of 1.0, the pace of new features may slow drastically.
+With the system going into a more passive bugfixing and maintenance mode with the release of 1.0, the pace of new features may slow drastically.
 As such, this project is open to accepting pull requests contributions from enterprising developers.
 That said, I plan on maintaining at least some coherence in the code style and quality of the codebase so new code.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contributing Guidelines
 
-With the system going into a more passive bugfixing and maintenance mode with the release of 1.0, the pace of new features may slow drastically.
+With the system going into a more passive bugfixing and maintane mode with the release of 1.0, the pace of new features may slow drastically.
 As such, this project is open to accepting pull requests contributions from enterprising developers.
 That said, I plan on maintaining at least some coherence in the code style and quality of the codebase so new code.
 

--- a/styles/character/bits.scss
+++ b/styles/character/bits.scss
@@ -10,6 +10,8 @@
             .bits-item-name {
                 cursor: pointer;
                 width: 100%;
+                font-weight: bold;
+
                 &:hover {
                     color: #800;
                 }
@@ -18,7 +20,8 @@
             input[type="checkbox"] {
                 width: 1em;
                 height: 1em;
-                margin: 0;
+                margin: 0 5px 0 2px;
+                vertical-align: middle;
             }
         }
         & > .bits-buttons {

--- a/templates/character-sheet.hbs
+++ b/templates/character-sheet.hbs
@@ -70,9 +70,9 @@
             <div class="bits-item flex-row">
                 <div class="bits-artha" draggable="true" data-id="{{belief._id}}">
                     <div class="bits-item-name" data-action="editItem" data-id="{{belief._id}}">{{belief.name}}</div>
-                    F:<input type="checkbox" data-item-id="{{belief._id}}" data-binding="data.fate" {{ checked belief.data.fate }}>
-                    P:<input type="checkbox" data-item-id="{{belief._id}}" data-binding="data.persona"  {{ checked belief.data.persona }}>
-                    D:<input type="checkbox" data-item-id="{{belief._id}}" data-binding="data.deeds" {{ checked belief.data.deeds }}>
+                    F<input type="checkbox" data-item-id="{{belief._id}}" data-binding="data.fate" {{ checked belief.data.fate }}>
+                    P<input type="checkbox" data-item-id="{{belief._id}}" data-binding="data.persona"  {{ checked belief.data.persona }}>
+                    D<input type="checkbox" data-item-id="{{belief._id}}" data-binding="data.deeds" {{ checked belief.data.deeds }}>
                 </div>
                 <div class="bits-buttons flex-column">
                     <i class="fas fa-comment" data-action="broadcast" data-id="{{belief._id}}"></i>
@@ -97,9 +97,9 @@
             <div class="bits-item flex-row">
                 <div class="bits-artha" draggable="true" data-id="{{instinct._id}}">
                     <div class="bits-item-name" data-action="editItem" data-id="{{instinct._id}}">{{instinct.name}}</div>
-                    F:<input type="checkbox" data-item-id="{{instinct._id}}" data-binding="data.fate" {{ checked instinct.data.fate }}>
-                    P:<input type="checkbox" data-item-id="{{instinct._id}}" data-binding="data.persona"  {{ checked instinct.data.persona }}>
-                    D:<input type="checkbox" data-item-id="{{instinct._id}}" data-binding="data.deeds" {{ checked instinct.data.deeds }}>
+                    F<input type="checkbox" data-item-id="{{instinct._id}}" data-binding="data.fate" {{ checked instinct.data.fate }}>
+                    P<input type="checkbox" data-item-id="{{instinct._id}}" data-binding="data.persona"  {{ checked instinct.data.persona }}>
+                    D<input type="checkbox" data-item-id="{{instinct._id}}" data-binding="data.deeds" {{ checked instinct.data.deeds }}>
                 </div>
                 <div class="bits-buttons flex-column">
                     <i class="fas fa-comment" data-action="broadcast" data-id="{{instinct._id}}"></i>


### PR DESCRIPTION
## Changes / Comments

I removed the colon from the Fate, Persona and Deeds checkboxes next to beliefs and instincts to reduce visual noise, aligned the checkbox to the line a little better and with the added space gave it all some breathing room. Finally I bolded the name of each row.

It's simple, but I hope it makes sense.

<img width="790" alt="Screen Shot 2021-02-16 at 9 17 38 PM" src="https://user-images.githubusercontent.com/203049/108147145-68c6cc00-709c-11eb-89da-0352baabbd57.png">


## Extra Info

Extra information for the fix is also quite helpful. Try to answer any relevant questions in the comment.
- [ ] Did this PR have to change `template.yml`?
- [ ] If so, were there any steps taken to protect existing user data? A migration task?
- [X] Did you follow the [contributing guidelines](https://github.com/StasTserk/foundry-burningwheel/blob/master/CONTRIBUTING.md)?
- [X] Is this PR limited to fixing just one issue?
