### PR TITLE
Type cleanup post 0.8.x upgrade

### DIFF
--- a/module/actors/BWActor.ts
+++ b/module/actors/BWActor.ts
@@ -6,11 +6,11 @@ import { Armor } from "../items/armor.js";
 import { PossessionRootData } from "../items/possession.js";
 import { ReputationDataRoot } from "../items/reputation.js";
 import { TraitDataRoot, Trait } from "../items/trait.js";
-import { BWCharacterData, CharacterDataRoot } from "./BWCharacter.js";
-import { NpcData, NpcDataRoot } from "./Npc.js";
+import { BWCharacterData } from "./BWCharacter.js";
+import { NpcData } from "./Npc.js";
 import { AffiliationDataRoot } from "../items/affiliation.js";
 
-export class BWActor<T extends BWActorData = BWActorDataTypes> extends Actor<T, BWItem> {
+export class BWActor<T extends BWActorData = BWActorData> extends Actor<T, BWItem> {
     data: T;
 
     readonly batchAdd = {
@@ -357,21 +357,17 @@ export class BWActor<T extends BWActorData = BWActorDataTypes> extends Actor<T, 
     }
 
     public updateArthaForSkill(_skillId: string, persona: number, deeds: number): void {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
-        this.update({
-            "data.deeds": this.data.data.deeds - (deeds ? 1 : 0),
-            "data.persona": this.data.data.persona - persona,
-        });
+        const updateData = {};
+        updateData["data.deeds"] = this.data.data.deeds - (deeds ? 1 : 0);
+        updateData["data.persona"] = this.data.data.persona - persona;
+        this.update(updateData);
     }
 
-    public updateArthaForStat(_accessor: string, persona: number, deeds: number): void {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
-        this.update({
-            "data.deeds": this.data.data.deeds - (deeds ? 1 : 0),
-            "data.persona": this.data.data.persona - persona,
-        });
+    public updateArthaForStat(accessor: string, persona: number, deeds: number): void {
+        const updateData = {};
+        updateData["data.deeds"] = this.data.data.deeds - (deeds ? 1 : 0);
+        updateData["data.persona"] = this.data.data.persona - persona;
+        this.update(updateData);
     }
 }
 
@@ -490,5 +486,3 @@ export interface NewItemData extends StringIndexedObject<any> {
     name: string;
     type: ItemType;
 }
-
-export type BWActorDataTypes = CharacterDataRoot | NpcDataRoot;

--- a/module/actors/BWCharacter.ts
+++ b/module/actors/BWCharacter.ts
@@ -8,18 +8,6 @@ export class BWCharacter extends BWActor<CharacterDataRoot> {
 
     prepareData(): void {
         super.prepareData();
-        if (!this.data.data.settings) {
-            this.data.data.settings = {
-                onlySuccessesCount: 'Faith, Resources, Perception',
-                showSettings: false,
-                roundUpHealth: false,
-                roundUpMortalWound: false,
-                roundUpReflexes: false,
-                armorTrained: false,
-                ignoreSuperficialWounds: false,
-                showBurner: false
-            };
-        }
 
         this._calculatePtgs();
 
@@ -363,7 +351,6 @@ export class BWCharacter extends BWActor<CharacterDataRoot> {
 }
 
 export interface CharacterDataRoot extends BWActorData<BWCharacterData> {
-    data: BWCharacterData;
     type: "character"
 }
 

--- a/module/actors/Npc.ts
+++ b/module/actors/Npc.ts
@@ -1,8 +1,7 @@
 import { Common, BWActor, BWActorData } from "./BWActor.js";
 import { ShadeString } from "../helpers.js";
 
-export class Npc extends BWActor {
-    data: NpcDataRoot;
+export class Npc extends BWActor<NpcDataRoot> {
 
     prepareData(): void {
         super.prepareData();
@@ -22,8 +21,7 @@ export class Npc extends BWActor {
 }
 
 export interface NpcDataRoot extends BWActorData<NpcData> {
-    data: NpcData;
-    // type: "npc"
+    type: "npc"
 }
 
 export interface NpcData extends Common {

--- a/module/actors/sheets/BWSettingSheet.ts
+++ b/module/actors/sheets/BWSettingSheet.ts
@@ -80,9 +80,9 @@ export class BWSettingSheet extends ActorSheet<BWSettingSheetData> {
                     }
                 }
             }
-        }).on('dragenter', _ => {
+        }).on('dragenter', () => {
             enterCount ++;
-        }).on('dragleave', _ => {
+        }).on('dragleave', () => {
             enterCount --;
             if (!enterCount) {
                 activeDropArea?.removeClass("show-drop");

--- a/module/factory.ts
+++ b/module/factory.ts
@@ -14,8 +14,9 @@ import { Trait } from "./items/trait.js";
 import { Npc } from "./actors/Npc.js";
 import { Lifepath } from "./items/lifepath.js";
 import { BWSetting } from "./actors/BWSetting.js";
+import { Affiliation } from "./items/affiliation.js";
 
-function factory(entities: Record<string, typeof FoundryDocument>, baseClass: typeof Entity): unknown {
+function factory(entities: Record<string, typeof FoundryDocument>, baseClass: typeof FoundryDocument): typeof FoundryDocument {
     return new Proxy(baseClass, {
         construct: (target, args) => {
             const [data, options] = args;
@@ -80,7 +81,7 @@ itemTypes["relationship"] = Relationship as typeof FoundryDocument;
 itemTypes["melee weapon"] = MeleeWeapon as typeof FoundryDocument;
 itemTypes["ranged weapon"] = RangedWeapon as typeof FoundryDocument;
 itemTypes["reputation"] = Reputation as typeof FoundryDocument;
-itemTypes["affiliation"] = Relationship as typeof FoundryDocument;
+itemTypes["affiliation"] = Affiliation as typeof FoundryDocument;
 itemTypes["spell"] = Spell as typeof FoundryDocument;
 itemTypes["lifepath"] = Lifepath as typeof FoundryDocument;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/module/items/affiliation.ts
+++ b/module/items/affiliation.ts
@@ -1,15 +1,9 @@
-import { BWItem, BWItemData, ItemType } from "./item.js";
+import { BWItem, BWItemData } from "./item.js";
 
-export class Affiliation extends BWItem {
-    data: AffiliationDataRoot;
-    get type(): ItemType {
-        return this.type as ItemType;
-    }
-}
+export class Affiliation extends BWItem<AffiliationDataRoot> { }
 
-export interface AffiliationDataRoot extends BWItemData {
-    data: AffiliationData;
-    type: ItemType;
+export interface AffiliationDataRoot extends BWItemData<AffiliationData> {
+    type: "affiliation";
 }
 
 export interface AffiliationData {

--- a/module/items/armor.ts
+++ b/module/items/armor.ts
@@ -2,7 +2,7 @@ import { BWItem, BWItemData, DisplayClass, HasPointCost } from "./item.js";
 import { rollDice } from "../rolls/rolls.js";
 import { ShadeString } from "../helpers.js";
 
-export class Armor extends BWItem {
+export class Armor extends BWItem<ArmorRootData> {
     prepareData(): void {
         super.prepareData();
         this.data.data.cssClass = "equipment-armor";
@@ -16,8 +16,6 @@ export class Armor extends BWItem {
         this.data.data.rightLegDisplayClass = this.calculateDisplayClass(dice, this.data.data.damageRightLeg);
         this.data.data.shieldDisplayClass = this.calculateDisplayClass(dice, this.data.data.damageShield);
     }
-
-    data: ArmorRootData;
 
     calculateDisplayClass(dice: number, locationDice: string): string {
         if (parseInt(locationDice) >= dice) {
@@ -58,8 +56,8 @@ export class Armor extends BWItem {
     }
 }
 
-export interface ArmorRootData extends BWItemData {
-    data: ArmorData;
+export interface ArmorRootData extends BWItemData<ArmorData> {
+    type: "armor"
 }
 
 export interface ArmorData extends DisplayClass, HasPointCost {

--- a/module/items/belief.ts
+++ b/module/items/belief.ts
@@ -2,8 +2,7 @@ import { simpleBroadcast, SimpleBroadcastMessageData } from "../chat.js";
 import { BWActor } from "../actors/BWActor.js";
 import { ArthaEarner, BWItem, BWItemData } from "./item.js";
 
-export class Belief extends BWItem {
-    data: BWItemData & { data: BeliefData };
+export class Belief extends BWItem<BWItemData<BeliefData>> {
 
     async generateChatMessage(actor: BWActor): Promise<ChatMessage | null> {
         const data: SimpleBroadcastMessageData = {

--- a/module/items/instinct.ts
+++ b/module/items/instinct.ts
@@ -2,9 +2,7 @@ import { simpleBroadcast, SimpleBroadcastMessageData } from "../chat.js";
 import { BWActor } from "../actors/BWActor.js";
 import { ArthaEarner, BWItem, BWItemData } from "./item.js";
 
-export class Instinct extends BWItem {
-    data: BWItemData & { data: InstinctData };
-
+export class Instinct extends BWItem<BWItemData<InstinctData>> {
     async generateChatMessage(actor: BWActor): Promise<ChatMessage | null> {
         const data: SimpleBroadcastMessageData = {
             title: this.name,

--- a/module/items/lifepath.ts
+++ b/module/items/lifepath.ts
@@ -1,7 +1,6 @@
 import { ItemType, BWItemData, BWItem } from "./item.js";
 
-export class Lifepath extends BWItem {
-    data: LifepathRootData;
+export class Lifepath extends BWItem<LifepathRootData> {
     get type(): ItemType {
         return super.type as ItemType;
     }
@@ -13,9 +12,8 @@ export class Lifepath extends BWItem {
     }
 }
 
-export interface LifepathRootData extends BWItemData {
-    data: LifepathData;
-    type: ItemType;
+export interface LifepathRootData extends BWItemData<LifepathData> {
+    type: "lifepath";
 }
 
 export interface LifepathData {

--- a/module/items/possession.ts
+++ b/module/items/possession.ts
@@ -1,16 +1,14 @@
 import { BWItem, BWItemData, DisplayClass, HasPointCost } from "./item.js";
 
-export class Possession extends BWItem {
+export class Possession extends BWItem<PossessionRootData> {
     prepareData(): void {
         super.prepareData();
         this.data.data.cssClass = "equipment-possession";
     }
-
-    data: PossessionRootData;
 }
 
-export interface PossessionRootData extends BWItemData {
-    data: PossessionData;
+export interface PossessionRootData extends BWItemData<PossessionData> {
+    type: "possession";
 }
 
 export interface PossessionData extends DisplayClass, HasPointCost {

--- a/module/items/property.ts
+++ b/module/items/property.ts
@@ -1,20 +1,15 @@
-import { DisplayClass, ItemType, HasPointCost, BWItemData, BWItem } from "./item.js";
+import { DisplayClass, HasPointCost, BWItemData, BWItem } from "./item.js";
 
-export class Property extends BWItem {
+export class Property extends BWItem<PropertyRootData> {
     prepareData(): void {
         super.prepareData();
         this.data.data.cssClass = "equipment-property";
     }
-
-    data: PropertyRootData;
-    get type(): ItemType {
-        return super.type as ItemType;
-    }
 }
 
-export interface PropertyRootData extends BWItemData {
+export interface PropertyRootData extends BWItemData<PropertyData> {
     data: PropertyData;
-    type: ItemType;
+    type: "property";
 }
 
 export interface PropertyData extends DisplayClass, HasPointCost {

--- a/module/items/rangedWeapon.ts
+++ b/module/items/rangedWeapon.ts
@@ -3,7 +3,7 @@ import * as helpers from "../helpers.js";
 import { QualityString } from "../constants.js";
 import { BWActor } from "../actors/BWActor.js";
 
-export class RangedWeapon extends BWItem {
+export class RangedWeapon extends BWItem<RangedWeaponRootData> {
     prepareData(): void {
         super.prepareData();
         const actor = this.actor as unknown as BWActor;
@@ -52,12 +52,10 @@ export class RangedWeapon extends BWItem {
         element.appendChild(helpers.DivOfText("" + roll, "roll-die"));
         return element.outerHTML;
     }
-
-    data: RangedWeaponRootData;
 }
 
-export interface RangedWeaponRootData extends BWItemData {
-    data: RangedWeaponData;
+export interface RangedWeaponRootData extends BWItemData<RangedWeaponData> {
+    type: "ranged weapon"
 }
 
 export interface RangedWeaponData extends DisplayClass, HasPointCost {

--- a/module/items/relationship.ts
+++ b/module/items/relationship.ts
@@ -1,6 +1,6 @@
 import { BWItem, BWItemData, DisplayClass } from "./item.js";
 
-export class Relationship extends BWItem {
+export class Relationship extends BWItem<RelationshipDataRoot> {
     prepareData(): void {
         super.prepareData();
         this.data.data.safeId = this.id;
@@ -16,12 +16,10 @@ export class Relationship extends BWItem {
             this.data.data.cssClass = "relationship-neutral";
         }
     }
-
-    data: RelationshipDataRoot;
 }
 
-export interface RelationshipDataRoot extends BWItemData {
-    data: RelationshipData;
+export interface RelationshipDataRoot extends BWItemData<RelationshipData> {
+    type: "relationship";
 }
 
 export interface RelationshipData extends DisplayClass {

--- a/module/items/reputation.ts
+++ b/module/items/reputation.ts
@@ -1,16 +1,14 @@
 import { BWItem, BWItemData, DisplayClass } from "./item.js";
 
-export class Reputation extends BWItem {
+export class Reputation extends BWItem<ReputationDataRoot> {
     prepareData(): void {
         super.prepareData();
         this.data.data.cssClass = this.data.data.infamous ? "reputation-infamous" : "reputation-famous";
     }
-
-    data: ReputationDataRoot;
 }
 
-export interface ReputationDataRoot extends BWItemData {
-    data: ReputationData;
+export interface ReputationDataRoot extends BWItemData<ReputationData> {
+    type: "reputation"
 }
 
 export interface ReputationData extends DisplayClass {

--- a/module/items/sheets/affiliation-sheet.ts
+++ b/module/items/sheets/affiliation-sheet.ts
@@ -1,10 +1,6 @@
 import { BWItemSheet } from "./bwItemSheet.js";
 
 export class AffiliationSheet extends BWItemSheet {
-    static get defaultOptions(): BaseEntitySheet.Options {
-        return mergeObject(super.defaultOptions, {});
-    }
-
     get template(): string {
         return "systems/burningwheel/templates/items/affiliation.hbs";
     }

--- a/module/items/skill.ts
+++ b/module/items/skill.ts
@@ -1,11 +1,11 @@
 import { skillRootSelect, SkillTypeString } from "../constants.js";
 import { Ability, BWActor, TracksTests } from "../actors/BWActor.js";
 import { ShadeString, StringIndexedObject, TestString, updateTestsNeeded } from "../helpers.js";
-import { DisplayClass, ItemType, BWItemData, BWItem } from "./item.js";
+import { DisplayClass, BWItemData, BWItem } from "./item.js";
 import { DifficultyDialog } from "../dialogs/DifficultyDialog.js";
 import * as helpers from "../helpers.js";
 
-export class Skill extends BWItem {
+export class Skill extends BWItem<SkillDataRoot> {
     getRootSelect(): StringIndexedObject<string> {
         const roots = {};
         const actor = this.actor as unknown as BWActor  | null;
@@ -55,12 +55,6 @@ export class Skill extends BWItem {
         if (!this.data.learning && this.data.exp <= woundDice) {
             this.data.cssClass += " wound-disabled";
         }
-    }
-
-    data: SkillDataRoot;
-
-    get type(): ItemType {
-        return super.type as ItemType;
     }
 
     canAdvance(): boolean {
@@ -198,8 +192,8 @@ export class Skill extends BWItem {
     }
 }
 
-export interface SkillDataRoot extends BWItemData {
-    data: SkillData;
+export interface SkillDataRoot extends BWItemData<SkillData> {
+    type: "skill";
 }
 
 export interface SkillData extends TracksTests, DisplayClass {

--- a/module/items/spell.ts
+++ b/module/items/spell.ts
@@ -3,7 +3,7 @@ import { weaponLengthSelect } from "../constants.js";
 import { StringIndexedObject, DivOfText } from "../helpers.js";
 import { HasPointCost, BWItemData, BWItem } from "./item.js";
 
-export class Spell extends BWItem {
+export class Spell extends BWItem<SpellDataRoot> {
     prepareData(): void {
         super.prepareData();
         const actor = this.actor as unknown as BWActor;
@@ -56,15 +56,12 @@ export class Spell extends BWItem {
         }
         return element.outerHTML;
     }
-
-    data: SpellDataRoot;
 }
 
-export interface SpellDataRoot extends BWItemData {
+export interface SpellDataRoot extends BWItemData<SpellData> {
     spellLengths: StringIndexedObject<string>;
     obstacleLabel: string;
-    type: "spell"
-    data: SpellData
+    type: "spell";
 }
 
 export interface SpellData extends HasPointCost {

--- a/module/items/trait.ts
+++ b/module/items/trait.ts
@@ -1,8 +1,8 @@
 import { simpleBroadcast, SimpleBroadcastMessageData } from "../chat.js";
 import { BWActor, RollModifier } from "../actors/BWActor.js";
-import { ItemType, HasPointCost, BWItemData, BWItem } from "./item.js";
+import { HasPointCost, BWItemData, BWItem } from "./item.js";
 
-export class Trait extends BWItem {
+export class Trait extends BWItem<TraitDataRoot> {
     prepareData(): void {
         super.prepareData();
         this.data.isCallonTrait = this.data.data.traittype === "call-on";
@@ -74,17 +74,12 @@ export class Trait extends BWItem {
         };
         return simpleBroadcast(data, actor);
     }
-
-    get type(): ItemType { return super.type as ItemType; }
-
-    data: TraitDataRoot;
 }
 
-export interface TraitDataRoot extends BWItemData {
-    type: ItemType;
+export interface TraitDataRoot extends BWItemData<TraitData> {
+    type: "trait";
     isDieTrait: boolean;
     isCallonTrait: boolean;
-    data: TraitData;
 }
 
 export interface TraitData extends HasPointCost {

--- a/module/migration/task063.ts
+++ b/module/migration/task063.ts
@@ -3,22 +3,22 @@ import { Trait } from "../items/trait.js";
 import { BWItem } from "../items/item.js";
 
 export async function task063(): Promise<void> {
-    const items: (Skill | Trait)[] = Array.from(game.items?.values() || []).filter((i: BWItem) => i.type === "skill" || i.type === "trait") as (Skill | Trait)[];
+    const items: (BWItem)[] = Array.from(game.items?.values() || []).filter((i: BWItem) => i.type === "skill" || i.type === "trait") as (BWItem)[];
     const updateInfo = {};
 
     for (const item of items) {
         const updateData = updateItem(item, updateInfo);
         if (Object.values(updateData).length) {
-            await item.update(updateData, {});
+            await item.update(updateData);
         }
     }
 
     const actors: Actor[] = Array.from(game.actors?.values() || []);
     for (const actor of actors) {
-        for (const ownedItem of Array.from(actor.items.values()).filter((i: BWItem) => i.type === "skill" || i.type === "trait") as (Skill | Trait)[]) {
+        for (const ownedItem of Array.from(actor.items.values()).filter((i: BWItem) => i.type === "skill" || i.type === "trait") as (BWItem)[]) {
             const updateData = updateItem(ownedItem, updateInfo);
             if (Object.values(updateData).length) {
-                await ownedItem.update(updateData, {});
+                await ownedItem.update(updateData);
             }
         }
     }
@@ -27,10 +27,10 @@ export async function task063(): Promise<void> {
     for (const pack of packs) {
         if (pack.documentName === "Item") {
             const packItems = await pack.getDocuments();
-            for (const item of Array.from(packItems.values()).filter((i: BWItem) => i.type === "skill" || i.type === "trait") as (Skill | Trait)[]) {
+            for (const item of Array.from(packItems.values()).filter((i: BWItem) => i.type === "skill" || i.type === "trait") as (BWItem)[]) {
                 const updateData = updateItem(item, updateInfo);
                 if (Object.values(updateData).length) {
-                    await item.update(updateData, {});
+                    await item.update(updateData);
                 }
             }
         }
@@ -45,7 +45,7 @@ export async function task063(): Promise<void> {
     ui.notifications?.notify(message, "info");
 }
 
-function updateItem(item: Skill | Trait, updateInfo: Record<string, number>): Record<string, string> {
+function updateItem(item: BWItem, updateInfo: Record<string, number>): Record<string, string> {
     const data = {};
     if (item.data.img === "icons/svg/item-bag.svg") {
         if (item.data.type === "skill") {


### PR DESCRIPTION
Fixes a number of issues noted in the 0.8.x upgrade pull request
Performs some cleanup on the types used for actors and items to keep
consistent use of generics.
Fixes an issue where the wrong item class was used for Affiliations in
the proxy class.

Resolves #340 