### PR TITLE
Update _preCreate to not use deprecated behavior

### DIFF
--- a/module/actors/BWActor.ts
+++ b/module/actors/BWActor.ts
@@ -235,17 +235,20 @@ export class BWActor<T extends BWActorData = BWActorData> extends Actor<T, BWIte
             // we aren't the person who created this actor
             return;
         }
-        this.createOwnedItem([
-            { name: "Instinct 1", type: "instinct", data: {}, img: constants.defaultImages.instinct},
-            { name: "Instinct 2", type: "instinct", data: {}, img: constants.defaultImages.instinct},
-            { name: "Instinct 3", type: "instinct", data: {}, img: constants.defaultImages.instinct},
-            { name: "Instinct Special", type: "instinct", data: {}, img: constants.defaultImages.instinct},
-            { name: "Belief 1", type: "belief", data: {}, img: constants.defaultImages.belief},
-            { name: "Belief 2", type: "belief", data: {}, img: constants.defaultImages.belief},
-            { name: "Belief 3", type: "belief", data: {}, img: constants.defaultImages.belief},
-            { name: "Belief Special", type: "belief", data: {}, img: constants.defaultImages.belief},
-            { ...constants.bareFistData, img: "icons/skills/melee/unarmed-punch-fist-yellow-red.webp" }
-        ]);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (this.data as any).update({
+            items: [
+                { name: "Instinct 1", type: "instinct", data: {}, img: constants.defaultImages.instinct },
+                { name: "Instinct 2", type: "instinct", data: {}, img: constants.defaultImages.instinct },
+                { name: "Instinct 3", type: "instinct", data: {}, img: constants.defaultImages.instinct },
+                { name: "Instinct Special", type: "instinct", data: {}, img: constants.defaultImages.instinct },
+                { name: "Belief 1", type: "belief", data: {}, img: constants.defaultImages.belief },
+                { name: "Belief 2", type: "belief", data: {}, img: constants.defaultImages.belief },
+                { name: "Belief 3", type: "belief", data: {}, img: constants.defaultImages.belief },
+                { name: "Belief Special", type: "belief", data: {}, img: constants.defaultImages.belief },
+                { ...constants.bareFistData, img: "icons/skills/melee/unarmed-punch-fist-yellow-red.webp" }
+            ]
+        });
     }
 
     async _preCreate(actor: Partial<T>, _options: FoundryDocument.CreateOptions, user: User): Promise<void> {


### PR DESCRIPTION
Removes use of getOwnedItems from _preCreate.
Relies on a bit of a bandaid fix due to missing types, but should be
the correct way to handle that process.
