### PR TITLE
Allow extended test overlay without GM difficulty

### DIFF
--- a/module/dialogs/DifficultyDialog.ts
+++ b/module/dialogs/DifficultyDialog.ts
@@ -7,6 +7,7 @@ import { gmOnly } from "../decorators.js";
 
 export class DifficultyDialog extends Application {
     difficulty: number;
+    showDifficulty: boolean;
     editable: boolean;
     splitPool: boolean;
     customDiff: boolean;
@@ -15,13 +16,14 @@ export class DifficultyDialog extends Application {
     extendedTest: boolean;
     actorGroups: ActorTestGroup[];
 
-    constructor(defaultDifficulty: number, extendedData?: { extendedTest?: boolean, actorGroups?: ActorTestGroup[] } ) {
+    constructor(defaultDifficulty: number, showDifficulty: boolean, extendedData?: { extendedTest?: boolean, actorGroups?: ActorTestGroup[] } ) {
         super({
             template: "systems/burningwheel/templates/dialogs/gm-difficulty.hbs",
             classes: ["gm-difficulty"],
             popOut: false
         });
         this.difficulty = defaultDifficulty;
+        this.showDifficulty = showDifficulty;
         this.editable = game.user?.isGM || false;
 
         this.splitPool = this.customDiff = this.help = false;
@@ -226,6 +228,7 @@ export class DifficultyDialog extends Application {
         
         data.extendedTest = this.extendedTest;
         data.actorGroups = this.actorGroups;
+        data.showDifficulty = this.showDifficulty;
 
         return data;
     }
@@ -237,6 +240,7 @@ interface DifficultyDialogData {
     help: boolean;
     splitPool: boolean;
     difficulty: number;
+    showDifficulty: boolean;
     editable: boolean;
     actorGroups: ActorTestGroup[];
 }

--- a/module/dialogs/ModifierDialog.ts
+++ b/module/dialogs/ModifierDialog.ts
@@ -10,14 +10,12 @@ export class ModifierDialog extends Application {
 
     mods: {name: string, amount: number }[];
     help: HelpRecord[];
-    cssClass: string;
 
-    constructor(showGmDifficulty: boolean, mods?: {name: string, amount: number}[], help?: HelpRecord[]) {
+    constructor(mods?: {name: string, amount: number}[], help?: HelpRecord[]) {
         super({
             template: "systems/burningwheel/templates/dialogs/mods-and-help.hbs",
             popOut: false,
         });
-        this.cssClass = showGmDifficulty ? "modifiers-and-difficulty" : "modifiers-only";
         this.mods = mods || [];
         this.help = help || [];
     }
@@ -178,7 +176,6 @@ export class ModifierDialog extends Application {
 
     getData(): DifficultyDialogData {
         const data = super.getData() as DifficultyDialogData;
-        data.cssClass = this.cssClass;
         data.editable = game.user?.isGM || false;
         data.modifiers = this.mods;
         data.help = this.help;
@@ -189,7 +186,6 @@ export class ModifierDialog extends Application {
 }
 
 interface DifficultyDialogData {
-    cssClass: string;
     editable: boolean;
     extendedTest: boolean;
     modifiers: { name: string; amount: number; }[];

--- a/module/dialogs/index.ts
+++ b/module/dialogs/index.ts
@@ -63,13 +63,11 @@ export async function initializeExtendedTestDialogs(): Promise<void> {
 
 export async function initializeRollPanels(): Promise<void> {
     game.burningwheel.useGmDifficulty = await game.settings.get(constants.systemName, constants.settings.useGmDifficulty) as boolean;
-    if (game.burningwheel.useGmDifficulty) {
-        const difficulty = await game.settings.get(constants.systemName, constants.settings.gmDifficulty) as number;
-        const testData = await JSON.parse(game.settings.get(constants.systemName, constants.settings.extendedTestData) as string);
-        game.burningwheel.gmDifficulty = new DifficultyDialog(difficulty, testData);
-        game.burningwheel.gmDifficulty.activateSocketListeners();
-        game.burningwheel.gmDifficulty.render(true);
-    }
+    const difficulty = await game.settings.get(constants.systemName, constants.settings.gmDifficulty) as number;
+    const testData = await JSON.parse(game.settings.get(constants.systemName, constants.settings.extendedTestData) as string);
+    game.burningwheel.gmDifficulty = new DifficultyDialog(difficulty, game.burningwheel.useGmDifficulty, testData);
+    game.burningwheel.gmDifficulty.activateSocketListeners();
+    game.burningwheel.gmDifficulty.render(true);
 
     let modData = { mods: undefined, help: undefined };
     try {
@@ -78,7 +76,7 @@ export async function initializeRollPanels(): Promise<void> {
         ui.notifications?.warn("Error parsing serialized Modifier data");
         console.error(err);
     }
-    game.burningwheel.modifiers = new ModifierDialog(game.burningwheel.useGmDifficulty, modData.mods, modData.help);
+    game.burningwheel.modifiers = new ModifierDialog(modData.mods, modData.help);
     game.burningwheel.modifiers.activateSocketListeners();
     game.burningwheel.modifiers.render(true);
 }

--- a/styles/dialog/difficulty.scss
+++ b/styles/dialog/difficulty.scss
@@ -20,7 +20,6 @@
 
 .difficulty-dialog {
     width: 5em;
-    height: 6.5em;
     position: fixed;
     bottom: 10px;
     right: 310px;

--- a/styles/dialog/mods-and-help.scss
+++ b/styles/dialog/mods-and-help.scss
@@ -1,16 +1,11 @@
 .mods-and-help {
     position: fixed;
+    right: calc(320px + 10em);
+
     bottom: 10px;
     
     display: flex;
     flex-direction: column;
-
-    &.modifiers-only {
-        right: 320px;
-    }
-    &.modifiers-and-difficulty {
-        right: calc(320px + 10em);
-    }
 
     & > div {
         width: 12em;      

--- a/templates/dialogs/gm-difficulty.hbs
+++ b/templates/dialogs/gm-difficulty.hbs
@@ -18,6 +18,7 @@
                 <label for="gm-diff-help" title="Provide Helping Dice">HLP</label>
             </div>
         </div>
+        {{#if showDifficulty}}
         <div class="obstacle">
             <div class="label">Obstacle</div>
             {{#if editable}}
@@ -28,6 +29,7 @@
             </div>
             {{/if}}
         </div>
+        {{/if}}
     </div>
     {{#if extendedTest}}
     <div class="extended-test">


### PR DESCRIPTION
Allow the extended test overlay to be displayed even when the GM
difficulty dialog is disabled.

Resolves #368