### PR TITLE
Move extended test dialog action options

### DIFF
--- a/module/burningwheel.ts
+++ b/module/burningwheel.ts
@@ -43,18 +43,22 @@ Hooks.once("init", async () => {
         types: ["setting"],
         makeDefault: true
     });
-    
-    RegisterItemSheets();
 
+    game.burningwheel.duelOfWitsActions = constants.DuelOfWitsActions;
+    game.burningwheel.fightActions = constants.FightActions;
+    game.burningwheel.rangeAndCoverActions = constants.RangeAndCoverActions;
+
+    RegisterItemSheets();
     registerSystemSettings();
     preloadHandlebarsTemplates();
     registerHelpers();
-    dialogs.initializeExtendedTestDialogs();
+    
 });
 
 Hooks.once("ready", async() => {
     await migrateData();
     await dialogs.initializeRollPanels();
+    await dialogs.initializeExtendedTestDialogs();
     RegisterMacros();
 });
 

--- a/module/constants.ts
+++ b/module/constants.ts
@@ -158,3 +158,63 @@ export const skillImages: { [k in SkillTypeString]: string } = {
     "social": "icons/skills/social/diplomacy-handshake-yellow.webp",
     "sorcerous": "icons/magic/fire/flame-burning-hand-white.webp",
 };
+
+export const RangeAndCoverActions: Record<string, string[]> = {
+    "Move In": [
+        "Close", "Sneak In", "Flank", "Charge"
+    ],
+    "Hold Ground": [
+        "Maintain Distance", "Hold Position"
+    ],
+    "Move Out": [
+        "Withdraw", "Sneak Out", "Fall Back", "Retreat"
+    ],
+    "Hesitation Actions": [
+        "Fall Prone", "Run Screaming", "Stand & Drool", "Swoon"
+    ]
+};
+
+export const FightActions: Record<string, string[]> = {
+    "Attack Actions": [
+        "Strike", "Great Strike", "Block and Strike", "Lock and Strike"
+    ],
+    "Defense Actions": [
+        "Avoid", "Block", "Counter&shy;strike"
+    ],
+    "Basic Actions": [
+        "Assess", "Change Stance", "Charge/&shy;Tackle", "Draw Weapon", "Physical Action", "Push", "Lock", "Get Up",
+    ],
+    "Special Actions": [
+        "Beat", "Disarm", "Feint", "Throw Person"
+    ],
+    "Shooting Actions": [
+        "Throw Object/&shy;Weapon", "Aim", "Nock and Draw", "Reload", "Fire", "Release Bow", "Snapshot"
+    ],
+    "Magic Actions": [
+        "Cast a Spell", "Drop Spell", "Command Spirit"
+    ],
+    "Social Actions": [
+        "Command", "Intimidate"
+    ],
+    "Hesitation Actions": [
+        "Fall Prone", "Run Screaming", "Stand & Drool", "Swoon"
+    ]
+};
+
+export const DuelOfWitsActions = {
+    "Verbal Attack": [
+        "Point", "Dismiss"
+    ],
+    "Verbal Defense": [
+        "Avoid", "Obfuscate", "Rebuttal"
+    ],
+    "Verbal Special": [
+        "Feint", "Incite"
+    ],
+    "Magic": [
+        "Cast Spell", "Command Spirit", "Drop Spell", "Sing, Howl, Pray"
+    ],
+    "Hesitation": [
+        "Fall Prone", "Run Screaming", "Stand & Drool", "Swoon"
+    ]
+};

--- a/module/dialogs/DuelOfWitsDialog.ts
+++ b/module/dialogs/DuelOfWitsDialog.ts
@@ -15,7 +15,7 @@ export class DuelOfWitsDialog extends ExtendedTestDialog<DuelOfWitsData> {
     constructor(d: Dialog.Data, o?: Dialog.Options) {
         super(d, o);
         
-        this.data.actionOptions = options;
+        this.data.actionOptions = game.burningwheel.duelOfWitsActions;
         this.data.data.showV1 = this.data.data.showV1 || false;
         this.data.data.showV2 = this.data.data.showV2 || false;
         this.data.data.showV3 = this.data.data.showV3 || false;
@@ -213,21 +213,3 @@ interface DuelOfWitsData {
 
     actionOptions: StringIndexedObject<string[]>;
 }
-
-const options = {
-    "Verbal Attack": [
-        "Point", "Dismiss"
-    ],
-    "Verbal Defense": [
-        "Avoid", "Obfuscate", "Rebuttal"
-    ],
-    "Verbal Special": [
-        "Feint", "Incite"
-    ],
-    "Magic": [
-        "Cast Spell", "Command Spirit", "Drop Spell", "Sing, Howl, Pray"
-    ],
-    "Hesitation": [
-        "Fall Prone", "Run Screaming", "Stand & Drool", "Swoon"
-    ]
-};

--- a/module/dialogs/FightDialog.ts
+++ b/module/dialogs/FightDialog.ts
@@ -16,7 +16,7 @@ export class FightDialog extends ExtendedTestDialog<FightDialogData> {
         super(d, o);
         this.data.data.participants = this.data.data.participants || [];
         this.data.data.participantIds = this.data.data.participantIds || [];
-        this.data.actionOptions = options;
+        this.data.actionOptions = game.burningwheel.fightActions;
         this.data.actors = [];
         this.data.topic = "Fight";
         this.data.settingName = "fight-data";
@@ -285,30 +285,3 @@ interface ParticipantEntry {
     action9: string;
     weapons?: { id: string, label: string }[];
 }
-
-const options = {
-    "Attack Actions": [
-        "Strike", "Great Strike", "Block and Strike", "Lock and Strike"
-    ],
-    "Defense Actions": [
-        "Avoid", "Block", "Counter&shy;strike"
-    ],
-    "Basic Actions": [
-        "Assess", "Change Stance", "Charge/&shy;Tackle", "Draw Weapon", "Physical Action", "Push", "Lock", "Get Up",
-    ],
-    "Special Actions": [
-        "Beat", "Disarm", "Feint", "Throw Person"
-    ],
-    "Shooting Actions": [
-        "Throw Object/&shy;Weapon", "Aim", "Nock and Draw", "Reload", "Fire", "Release Bow", "Snapshot"
-    ],
-    "Magic Actions": [
-        "Cast a Spell", "Drop Spell", "Command Spirit"
-    ],
-    "Social Actions": [
-        "Command", "Intimidate"
-    ],
-    "Hesitation Actions": [
-        "Fall Prone", "Run Screaming", "Stand & Drool", "Swoon"
-    ]
-};

--- a/module/dialogs/RangeAndCoverDialog.ts
+++ b/module/dialogs/RangeAndCoverDialog.ts
@@ -129,7 +129,7 @@ export class RangeAndCoverDialog extends ExtendedTestDialog<RangeAndCoverData> {
 
     getData(): RangeAndCoverData {
         const data = super.getData() as RangeAndCoverData;
-        data.actionOptions = options;
+        data.actionOptions = game.burningwheel.rangeAndCoverActions;
         if (!this.data.actors) {
             this.data.actors = game.actors?.contents as BWActor[];
         }
@@ -182,17 +182,4 @@ interface RnCTeam {
     miscDice: number;
 }
 
-const options = {
-    "Move In": [
-        "Close", "Sneak In", "Flank", "Charge"
-    ],
-    "Hold Ground": [
-        "Maintain Distance", "Hold Position"
-    ],
-    "Move Out": [
-        "Withdraw", "Sneak Out", "Fall Back", "Retreat"
-    ],
-    "Hesitation Actions": [
-        "Fall Prone", "Run Screaming", "Stand & Drool", "Swoon"
-    ]
-};
+

--- a/types/overrides.d.ts
+++ b/types/overrides.d.ts
@@ -64,7 +64,10 @@ declare class BWGame extends Game {
         fight: FightDialog;
         rangeAndCover: RangeAndCoverDialog;
         modifiers: ModifierDialog;
-        macros: { [k: string]: (...args: unknown[]) => void}
+        macros: { [k: string]: (...args: unknown[]) => void };
+        duelOfWitsActions: Record<string, string[]>;
+        fightActions: Record<string, string[]>;
+        rangeAndCoverActions: Record<string, string[]>;
     };
 
     /** Optional Dice so Nice module */


### PR DESCRIPTION
Moves the extended test dialog action options to `constants.js`, adds them to the system for dialog import.

Also moves the dialog initialization to later in the initialization flow (on `ready` rather than on `init`) so a theoretical module may have time to modify said constants before they are loaded in as dialog options.

Resolves #400 
