### PR TITLE
Extra attribute modifiers in lifepaths (Double Physical mod, Double Mental mod)

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -243,6 +243,8 @@ BW:
     physical: Physical
     either: Either
     both: Both
+    phystwo: Physical (x2)
+    menttwo: Mental (x2)
     subtractStats: Subtract Stats
     leads: Leads
     skillPoints: Skill Points
@@ -268,7 +270,7 @@ BW:
     asMissile: As Missile
     optimalRange: Optimal Range
     halfWill: Half Will
-    halfWillHelp: This spell's damage is base off of half the will exponent, rather than the full one.
+    halfWillHelp: This spell's damage is based off of half the will exponent, rather than the full one.
     newSpell: A brand new spell
     tenPaces: 10 Paces
     taxTest: "{name} Tax Test"

--- a/module/dialogs/CharacterBurnerDialog.ts
+++ b/module/dialogs/CharacterBurnerDialog.ts
@@ -346,12 +346,14 @@ export class CharacterBurnerDialog extends Application {
                 physicalPoints.val(boostAmount).trigger('change');
                 break;
             case "mentwo":
-                mentalPoints.val(boostAmount).trigger('change');
+                mentalPoints.val(2*boostAmount).trigger('change');
+                break;
             case "mental":
                 mentalPoints.val(boostAmount).trigger('change');
                 break;
             case "phystwo":
-                physicalPoints.val(boostAmount).trigger('change');
+                physicalPoints.val(2*boostAmount).trigger('change');
+                break;
             case "physical":
                 physicalPoints.val(boostAmount).trigger('change');
                 break;

--- a/module/dialogs/CharacterBurnerDialog.ts
+++ b/module/dialogs/CharacterBurnerDialog.ts
@@ -340,14 +340,18 @@ export class CharacterBurnerDialog extends Application {
         const physicalPoints = emptyLifepath.nextAll('.inline-text').first().next().children('input[name="physicalStat"]').first();
         const boostAmount = pathData.subtractStats ? -1 : 1;
 
-        switch (pathData.statBoost) {
+        switch (pathData.statBoost) { 
             case "both":
                 mentalPoints.val(boostAmount).trigger('change');
                 physicalPoints.val(boostAmount).trigger('change');
                 break;
+            case "mentwo":
+                mentalPoints.val(boostAmount).trigger('change');
             case "mental":
                 mentalPoints.val(boostAmount).trigger('change');
                 break;
+            case "phystwo":
+                physicalPoints.val(boostAmount).trigger('change');
             case "physical":
                 physicalPoints.val(boostAmount).trigger('change');
                 break;

--- a/module/dialogs/CharacterBurnerDialog.ts
+++ b/module/dialogs/CharacterBurnerDialog.ts
@@ -345,7 +345,7 @@ export class CharacterBurnerDialog extends Application {
                 mentalPoints.val(boostAmount).trigger('change');
                 physicalPoints.val(boostAmount).trigger('change');
                 break;
-            case "mentwo":
+            case "menttwo":
                 mentalPoints.val(2*boostAmount).trigger('change');
                 break;
             case "mental":

--- a/module/items/lifepath.ts
+++ b/module/items/lifepath.ts
@@ -22,7 +22,7 @@ export class Lifepath extends BWItem<LifepathData> {
 export interface LifepathData {
     time: number;
     resources: number;
-    statBoost: 'none' | 'mental' | 'physical' | 'either' | 'both';
+    statBoost: 'none' | 'mental' | 'physical' | 'either' | 'both' | 'phystwo' | 'menttwo';
     subtractStats: boolean;
     leads: string;
     skillPoints: number;
@@ -44,5 +44,7 @@ const statMap = {
     "mental": "1 M",
     "physical": "1 P",
     "either": "1 M/P",
-    "both": "1 M,P"
+    "both": "1 M,P",
+    "phystwo": "2 P",
+    "menttwo": "2 M"
 };

--- a/templates/items/lifepath.hbs
+++ b/templates/items/lifepath.hbs
@@ -24,6 +24,8 @@
             <option value="physical">{{localize "BW.lifepath.physical"}}</option>
             <option value="either">{{localize "BW.lifepath.either"}}</option>
             <option value="both">{{localize "BW.lifepath.both"}}</option>
+            <option value="phystwo">{{localize "BW.lifepath.phystwo"}}</option>
+            <option value="menttwo">{{localize "BW.lifepath.menttwo"}}</option>
             {{/select}}
         </select>
         <div class="pill-toggle min-content">


### PR DESCRIPTION
## Changes / Comments

Adds functionality to provide the option of +2P lifepaths (needed for some Troll lifepaths), and also +2M (because once that's done anyone else who wants to add a +2M lifepath mirroring the +2P can).

I think I've added bits all the places they have mechanical effects...

Resolves hopefully, #379 

## Extra Info

Extra information for the fix is also quite helpful. Try to answer any relevant questions in the comment.
- [ x] Did this PR have to change `template.yml`?
- [ N/A] If so, were there any steps taken to protect existing user data? A migration task?
- [Y ] Did you follow the [contributing guidelines](https://github.com/StasTserk/foundry-burningwheel/blob/master/CONTRIBUTING.md)?
- [ Y] Is this PR limited to fixing just one issue?
