### PR TITLE
Fix an hasOwner flag error in skill sheet

### DIFF
--- a/templates/items/skill.hbs
+++ b/templates/items/skill.hbs
@@ -56,7 +56,7 @@
         </select>
     </div>
     <div class='item-form-group'>
-        {{#if item.system.hasOwner}}
+        {{#if item.hasOwner}}
             <label
                 for='{{item.id}}-aptitude'
                 class='item-setting-label'


### PR DESCRIPTION
Fixes an issue that was preventing some fields from appearing on an owned skill

Resolves #501 