### PR TITLE
Fix unfinished localisation - Removed this.updateSource from spell.ts

### DIFF
--- a/module/items/spell.ts
+++ b/module/items/spell.ts
@@ -84,10 +84,6 @@ export class Spell extends BWItem<SpellData> {
         user: User
     ): void {
         super._preCreate(data, options, user);
-        this.updateSource({
-            'system.maxRange': game.i18n.localize('BW.spell.tenPaces'),
-            'system.description': game.i18n.localize('BW.spell.newSpell'),
-        });
     }
 
     spellLengths: StringIndexedObject<string>;


### PR DESCRIPTION
Previous behavior:  Any spell added to or imported from a compendium would have its description replaced with "a brand new spell" and its max range replaced with "10 paces"

New behavior: Spells added to or imported from compendiums retain their Max range and descriptions

## Changes / Comments

Removed this.updateSource from spell.ts 

## Extra Info

Extra information for the fix is also quite helpful. Try to answer any relevant questions in the comment.

-   [ ] Did this PR have to change `template.yml`? - No
-   [ ] If so, were there any steps taken to protect existing user data? A migration task? N/A
-   [x] Did you follow the [contributing guidelines](https://github.com/StasTserk/foundry-burningwheel/blob/master/CONTRIBUTING.md)?
-   [x] Is this PR limited to fixing just one issue? Yes
