### PR TITLE
Avoid using globalThis duplicate

### DIFF
--- a/module/dialogs/CharacterBurnerDialog.ts
+++ b/module/dialogs/CharacterBurnerDialog.ts
@@ -689,7 +689,7 @@ export class CharacterBurnerDialog extends Application {
         }
     }
     private _addLifepath(lp: Lifepath) {
-        const pathData = duplicate(lp.system) as LifepathData;
+        const pathData = foundry.utils.duplicate(lp.system) as LifepathData;
         const numDuplicates = $(this.element)
             .find('input[name="lifepathName"]')
             .filter((_, e) => $(e).val() === lp.name).length;


### PR DESCRIPTION
Missed this one in the v12, but we can wait till the next release.