### PR TITLE
Fix wound penalty to Steel rolls

### DIFF
--- a/module/rolls/rollAttribute.ts
+++ b/module/rolls/rollAttribute.ts
@@ -48,11 +48,11 @@ export async function handleAttrRoll({
 }: AttributeRollOptions): Promise<unknown> {
     const rollModifiers = actor.getRollModifiers(attrName);
     dataPreset = dataPreset || {};
-    const woundDice =
-        attrName === 'Steel' ? actor.system.ptgs.woundDice : undefined;
-    const obPenalty =
-        attrName === 'Steel' ? actor.system.ptgs.obPenalty : undefined;
-    if (attrName.toLowerCase() === 'steel') {
+
+    const isSteel = attrName.toLowerCase() === 'steel';
+    const woundDice = isSteel ? actor.system.ptgs.woundDice : undefined;
+    const obPenalty = isSteel ? actor.system.ptgs.obPenalty : undefined;
+    if (isSteel) {
         dataPreset.useCustomDifficulty = true;
         dataPreset.showDifficulty = true;
         dataPreset.showObstacles = true;


### PR DESCRIPTION
## Changes / Comments

Wound penalty to Steel rolls wasn't working correctly because the comparison wasn't considering lower case only. Fixed that.
Also cached the comparison result since it is used 3 times in a row.

## Extra Info

Extra information for the fix is also quite helpful. Try to answer any relevant questions in the comment.

-   [ ] Did this PR have to change `template.yml`?
-   [ ] If so, were there any steps taken to protect existing user data? A migration task?
-   [ ] Did you follow the [contributing guidelines](https://github.com/StasTserk/foundry-burningwheel/blob/master/CONTRIBUTING.md)?
-   [ ] Is this PR limited to fixing just one issue?
