### PR TITLE
Fix shaded Stat aptitude

### DIFF
--- a/module/items/skill.ts
+++ b/module/items/skill.ts
@@ -62,9 +62,13 @@ export class Skill extends BWItem<SkillData> {
             +actor.getAptitudeModifiers(this.system.root2);
         }
 
-        const root1exp = (actor.system[this.system.root1] as Ability).exp;
+        const root1 = actor.system[this.system.root1] as Ability;
+        const root1exp =
+            root1.exp + (root1.shade === 'W' ? 2 : root1.shade === 'G' ? 1 : 0);
+        const root2 = actor.system[this.system.root2] as Ability;
         const root2exp = this.system.root2
-            ? (actor.system[this.system.root2] as Ability).exp
+            ? root2.exp +
+              (root2.shade === 'W' ? 2 : root2.shade === 'G' ? 1 : 0)
             : root1exp;
         const rootAvg = Math.floor((root1exp + root2exp) / 2);
         this.system.aptitude = 10 - rootAvg + aptitudeMod;


### PR DESCRIPTION
## Changes / Comments

Shaded stats should reduce the Aptitude for all skills rooted from it by 1 for Gray shade, and by 2 for White shade. This is buried in the Heroic and Supernatural chapter (Burning Wheel Gold Revised, page 545).

## Extra Info

Hesitation is calculated correctly, which is also reduced by the Will shade.

Extra information for the fix is also quite helpful. Try to answer any relevant questions in the comment.

-   [ ] Did this PR have to change `template.yml`?
-   [ ] If so, were there any steps taken to protect existing user data? A migration task?
-   [x] Did you follow the [contributing guidelines](https://github.com/StasTserk/foundry-burningwheel/blob/master/CONTRIBUTING.md)?
-   [x] Is this PR limited to fixing just one issue?
