### PR TITLE
Use historical test timings from junit report.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           username: stastserk
           password: $dockerhub_token
     resource_class: large
-    parallelism: 2
+    parallelism: 4
     environment:
       FOUNDRY_VERSION: '331'
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
             # This host entry allows us to continue using localhost which is critical for running the site with "low security mode" (http).
             tee -a /etc/hosts \<<<'172.17.0.1 localhost'
             TESTFILES=$(circleci tests glob "tests/**/*.spec.ts")
-            echo "$TESTFILES" | circleci tests run --command="xargs npm run playwright" --verbose --split-by=timings
+            echo "$TESTFILES" | circleci tests run --command="xargs npm run playwright" --verbose --split-by=timings --timings-type=classname
       - store_artifacts:
           path: results
       - store_test_results:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ import { defineConfig, devices } from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-    testDir: './tests',
+    testDir: './',
     /* Run tests in files in parallel */
     fullyParallel: true,
     /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
## Changes / Comments
Tries to fix the issue where test timings were not being properly accounted for in test splitting.

Also bumps parallelism up to 4 because why not.