### PR TITLE
Playwright item creation tests.

### DIFF
--- a/tests/fixtures/bwFixture.ts
+++ b/tests/fixtures/bwFixture.ts
@@ -1,9 +1,23 @@
 import { test as testLoggedOut, testAsGm as testLoggedIn } from './gameFixture';
+import { AffiliationFixture } from './parts/AffiliationFixture';
+import { ArmorFixture } from './parts/ArmorFixture';
+import { BeliefFixture } from './parts/BeliefFixture';
 import { CharacterFixture } from './parts/CharacterFixture';
 import { DoWDialog } from './parts/DoWDialog';
 import { FightDialog } from './parts/FightDialog';
+import { InstinctFixture } from './parts/InstinctFixture';
+import { LifepathFixture } from './parts/LifepathFixture';
+import { MeleeWeaponFixture } from './parts/MeleeWeaponFixture';
+import { PossessionFixture } from './parts/PossessionFixture';
+import { PropertyFixture } from './parts/PropertyFixture';
 import { RangeAndCoverDialog } from './parts/RangeAndCoverDialog';
+import { RangedWeaponFixture } from './parts/RangedWeaponFixture';
+import { RelationshipFixture } from './parts/RelationshipFixture';
+import { ReputationFixture } from './parts/ReputationFixture';
 import { RollDialog } from './parts/RollDialog';
+import { SkillFixture } from './parts/SkillFixture';
+import { SpellFixture } from './parts/SpellFixture';
+import { TraitFixture } from './parts/TraitFixture';
 
 export type FixtureBase = typeof testLoggedOut & typeof testLoggedIn;
 
@@ -13,6 +27,22 @@ type BwFixture = {
     rncDialog: RangeAndCoverDialog;
     rollDialog: RollDialog;
     char: CharacterFixture;
+    items: {
+        aff: AffiliationFixture;
+        armor: ArmorFixture;
+        belief: BeliefFixture;
+        instinct: InstinctFixture;
+        lp: LifepathFixture;
+        melee: MeleeWeaponFixture;
+        poss: PossessionFixture;
+        prop: PropertyFixture;
+        ranged: RangedWeaponFixture;
+        rel: RelationshipFixture;
+        rep: ReputationFixture;
+        skill: SkillFixture;
+        spell: SpellFixture;
+        trait: TraitFixture;
+    };
 };
 
 const extender: Parameters<typeof testLoggedIn.extend<BwFixture>>[0] = {
@@ -25,6 +55,23 @@ const extender: Parameters<typeof testLoggedIn.extend<BwFixture>>[0] = {
         await use(new RangeAndCoverDialog(page, gamePage, test)),
     char: async ({ page, gamePage }, use) =>
         await use(new CharacterFixture(page, gamePage, test)),
+    items: async ({ page, gamePage }, use) =>
+        await use({
+            aff: new AffiliationFixture(page, gamePage, test),
+            armor: new ArmorFixture(page, gamePage, test),
+            belief: new BeliefFixture(page, gamePage, test),
+            instinct: new InstinctFixture(page, gamePage, test),
+            lp: new LifepathFixture(page, gamePage, test),
+            melee: new MeleeWeaponFixture(page, gamePage, test),
+            poss: new PossessionFixture(page, gamePage, test),
+            prop: new PropertyFixture(page, gamePage, test),
+            ranged: new RangedWeaponFixture(page, gamePage, test),
+            rel: new RelationshipFixture(page, gamePage, test),
+            rep: new ReputationFixture(page, gamePage, test),
+            skill: new SpellFixture(page, gamePage, test),
+            spell: new SkillFixture(page, gamePage, test),
+            trait: new TraitFixture(page, gamePage, test),
+        }),
 };
 
 export const test = testLoggedOut.extend<BwFixture>(extender);

--- a/tests/fixtures/gameFixture.ts
+++ b/tests/fixtures/gameFixture.ts
@@ -13,6 +13,22 @@ type TabName =
     | 'Playlists'
     | 'Compendium Packs';
 
+type ItemType =
+    | 'affiliation'
+    | 'armor'
+    | 'belief'
+    | 'instinct'
+    | 'lifepath'
+    | 'melee weapon'
+    | 'possession'
+    | 'property'
+    | 'ranged weapon'
+    | 'relationship'
+    | 'reputation'
+    | 'skill'
+    | 'spell'
+    | 'trait';
+
 export class GameFixture {
     private activeTab: TabName = 'Chat Messages';
     constructor(private readonly page: Page, private readonly host: string) {}
@@ -87,6 +103,29 @@ export class GameFixture {
                 .selectOption(type);
             await this.page
                 .getByRole('button', { name: /create new actor/i })
+                .click();
+        });
+    }
+
+    async createItem(name: string, type: ItemType) {
+        await this.openTab('Items');
+        await test.step(`Create a(n) ${type} named ${name}`, async () => {
+            await this.page
+                .getByRole('button', { name: 'Create Item' })
+                .click();
+            await expect(
+                this.page.locator('form#document-create')
+            ).toBeVisible();
+            await this.page
+                .locator('form#document-create')
+                .getByRole('textbox')
+                .fill(name);
+            await this.page
+                .locator('form#document-create')
+                .getByRole('combobox')
+                .selectOption(type);
+            await this.page
+                .getByRole('button', { name: /create new item/i })
                 .click();
         });
     }

--- a/tests/fixtures/parts/AffiliationFixture.ts
+++ b/tests/fixtures/parts/AffiliationFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class AffiliationFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/ArmorFixture.ts
+++ b/tests/fixtures/parts/ArmorFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class ArmorFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/BaseItemFixture.ts
+++ b/tests/fixtures/parts/BaseItemFixture.ts
@@ -1,0 +1,29 @@
+import { expect, Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+
+export class BaseItemFixture {
+    constructor(
+        private readonly page: Page,
+        private readonly gamePage: GameFixture,
+        private readonly test: FixtureBase
+    ) {}
+
+    async open(name: string) {
+        await this.gamePage.openTab('Items');
+        await this.test.step(`Open item named '${name}'`, async () => {
+            await this.page.getByText(name).click();
+            await this.expectOpened(name);
+        });
+    }
+
+    expectOpened(name: string) {
+        return expect(
+            this.page.locator('div.app.bw-app').filter({ hasText: name })
+        ).toBeVisible();
+    }
+
+    sheet(name: string) {
+        return this.page.locator('div.app.bw-app').filter({ hasText: name });
+    }
+}

--- a/tests/fixtures/parts/BeliefFixture.ts
+++ b/tests/fixtures/parts/BeliefFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class BeliefFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/InstinctFixture.ts
+++ b/tests/fixtures/parts/InstinctFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class InstinctFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/LifepathFixture.ts
+++ b/tests/fixtures/parts/LifepathFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class LifepathFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/MeleeWeaponFixture.ts
+++ b/tests/fixtures/parts/MeleeWeaponFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class MeleeWeaponFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/PossessionFixture.ts
+++ b/tests/fixtures/parts/PossessionFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class PossessionFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/PropertyFixture.ts
+++ b/tests/fixtures/parts/PropertyFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class PropertyFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/RangedWeaponFixture.ts
+++ b/tests/fixtures/parts/RangedWeaponFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class RangedWeaponFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/RelationshipFixture.ts
+++ b/tests/fixtures/parts/RelationshipFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class RelationshipFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/ReputationFixture.ts
+++ b/tests/fixtures/parts/ReputationFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class ReputationFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/SkillFixture.ts
+++ b/tests/fixtures/parts/SkillFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class SkillFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/SpellFixture.ts
+++ b/tests/fixtures/parts/SpellFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class SpellFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/fixtures/parts/TraitFixture.ts
+++ b/tests/fixtures/parts/TraitFixture.ts
@@ -1,0 +1,10 @@
+import { Page } from 'playwright/test';
+import { FixtureBase } from '../bwFixture';
+import { GameFixture } from '../gameFixture';
+import { BaseItemFixture } from './BaseItemFixture';
+
+export class TraitFixture extends BaseItemFixture {
+    constructor(page: Page, gamePage: GameFixture, test: FixtureBase) {
+        super(page, gamePage, test);
+    }
+}

--- a/tests/items/affiliation.spec.ts
+++ b/tests/items/affiliation.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Affiliation', 'affiliation');
+    await items.aff.expectOpened('Test Affiliation');
+});

--- a/tests/items/armor.spec.ts
+++ b/tests/items/armor.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Armor', 'armor');
+    await items.armor.expectOpened('Test Armor');
+});

--- a/tests/items/belief.spec.ts
+++ b/tests/items/belief.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Belief', 'belief');
+    await items.belief.expectOpened('Test Belief');
+});

--- a/tests/items/instinct.spec.ts
+++ b/tests/items/instinct.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Instinct', 'instinct');
+    await items.instinct.expectOpened('Test Instinct');
+});

--- a/tests/items/lifepath.spec.ts
+++ b/tests/items/lifepath.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Lifepath', 'lifepath');
+    await items.lp.expectOpened('Test Lifepath');
+});

--- a/tests/items/melee-weapon.spec.ts
+++ b/tests/items/melee-weapon.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Melee Weapon', 'melee weapon');
+    await items.melee.expectOpened('Test Melee Weapon');
+});

--- a/tests/items/possession.spec.ts
+++ b/tests/items/possession.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Possession', 'possession');
+    await items.poss.expectOpened('Test Possession');
+});

--- a/tests/items/property.spec.ts
+++ b/tests/items/property.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Property', 'property');
+    await items.prop.expectOpened('Test Property');
+});

--- a/tests/items/ranged-weapon.spec.ts
+++ b/tests/items/ranged-weapon.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Ranged Weapon', 'ranged weapon');
+    await items.ranged.expectOpened('Test Ranged Weapon');
+});

--- a/tests/items/relationship.spec.ts
+++ b/tests/items/relationship.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Relationship', 'relationship');
+    await items.rel.expectOpened('Test Relationship');
+});

--- a/tests/items/reputation.spec.ts
+++ b/tests/items/reputation.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Reputation', 'reputation');
+    await items.rep.expectOpened('Test Reputation');
+});

--- a/tests/items/skill.spec.ts
+++ b/tests/items/skill.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Skill', 'skill');
+    await items.skill.expectOpened('Test skill');
+});

--- a/tests/items/spell.spec.ts
+++ b/tests/items/spell.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Spell', 'spell');
+    await items.spell.expectOpened('Test Spell');
+});

--- a/tests/items/trait.spec.ts
+++ b/tests/items/trait.spec.ts
@@ -1,0 +1,6 @@
+import { testAsGm as test } from '../fixtures/bwFixture';
+
+test('can be created, opens sheet', async ({ gamePage, items }) => {
+    await gamePage.createItem('Test Trait', 'trait');
+    await items.trait.expectOpened('Test Trait');
+});


### PR DESCRIPTION
## Changes / Comments
Adds a basic test for creating each individual item type.

Relates to #537 (but does not resolve).

Part of load testing the pipeline, also.
