### PR TITLE
Fix armor damage not increasing beyond 1

### DIFF
--- a/module/items/armor.ts
+++ b/module/items/armor.ts
@@ -53,9 +53,7 @@ export class Armor extends BWItem<ArmorData> {
 
         const locationAccessor = `system.damage${location}`;
         const damage =
-            parseInt(
-                foundry.utils.getProperty(this, `system.${locationAccessor}`)
-            ) || 0;
+            parseInt(foundry.utils.getProperty(this, locationAccessor)) || 0;
         const updateData = {};
         let newDamage = 0;
         switch (this.system.quality) {


### PR DESCRIPTION
## Changes / Comments

Fix armor key lookup when setting the damage, as described by this issue: https://github.com/StasTserk/foundry-burningwheel/issues/563

It should be right now.

## Extra Info

-   [ ] Did this PR have to change `template.yml`?
-   [ ] If so, were there any steps taken to protect existing user data? A migration task?
-   [ ] Did you follow the [contributing guidelines](https://github.com/StasTserk/foundry-burningwheel/blob/master/CONTRIBUTING.md)?
-   [ ] Is this PR limited to fixing just one issue?
