### PR TITLE
Fix an issue with counting wild fork totals

### DIFF
--- a/module/rolls/customRolls.ts
+++ b/module/rolls/customRolls.ts
@@ -9,7 +9,7 @@ export class AstrologyDie extends foundry.dice.terms.Die {
         super({
             number: diceNumber,
             faces: 6,
-            modifiers: ['x', `cs>${target}`, 'cf1'],
+            modifiers: ['x', `cs>${target}`, `cf`],
             options: {},
         });
     }
@@ -32,6 +32,13 @@ export class AstrologyDie extends foundry.dice.terms.Die {
                 r.count = -1;
             }
         }
+    }
+
+    get total() {
+        return this.results.reduce(
+            (acc, r) => (r.active ? (r.count ?? 0) + acc : acc),
+            0
+        );
     }
 }
 


### PR DESCRIPTION
Something in foundry's dice class changed and it started going crazy on the wild fork dice count

Resolves #569 
