### PR TITLE
Subtract wound penalties from help and fork exponent

### DIFF
--- a/module/actors/BWActor.ts
+++ b/module/actors/BWActor.ts
@@ -94,7 +94,12 @@ export class BWActor<T extends Common = Common> extends Actor<
                             .ptgs.woundDice || 0)
             )
             .map((s) => {
-                const exp = s.system.exp;
+                // subtract wound penalty to determine fork bonus.
+                const woundDice =
+                    (this.system as unknown as BWCharacterData | NpcData).ptgs
+                        .woundDice || 0;
+                const exp = s.system.exp - woundDice;
+
                 // skills at 7+ exp provide 2 dice in forks.
                 return { name: s.name, amount: exp >= 7 ? 2 : 1 };
             });
@@ -110,7 +115,12 @@ export class BWActor<T extends Common = Common> extends Actor<
                             .ptgs.woundDice || 0)
             )
             .map((s) => {
-                const exp = s.system.exp;
+                // subtract wound penalty to determine fork bonus.
+                const woundDice =
+                    (this.system as unknown as BWCharacterData | NpcData).ptgs
+                        .woundDice || 0;
+                const exp = s.system.exp - woundDice;
+
                 // skills at 7+ exp provide 2 dice in forks.
                 return { name: s.name, amount: exp >= 7 ? 2 : 1 };
             });

--- a/module/rolls/npcSkillRoll.ts
+++ b/module/rolls/npcSkillRoll.ts
@@ -173,7 +173,7 @@ export async function handleNpcSkillRoll({
     if (dataPreset && dataPreset.addHelp) {
         // add a test log instead of testing
         return buildHelpDialog({
-            exponent: skill.system.exp,
+            exponent: skill.system.exp - (actor.system.ptgs.woundDice ?? 0),
             skillId: skill.id,
             actor,
             helpedWith: skill.name,

--- a/module/rolls/npcStatRoll.ts
+++ b/module/rolls/npcStatRoll.ts
@@ -68,10 +68,15 @@ export async function handleNpcStatRoll({
         ]);
     }
 
+    const woundDice =
+        ['circles', 'resources', 'health'].indexOf(accessor) === -1
+            ? actor.system.ptgs.woundDice ?? 0
+            : 0;
+
     if (dataPreset && dataPreset.addHelp) {
         // add a test log instead of testing
         return buildHelpDialog({
-            exponent: dice,
+            exponent: dice - woundDice,
             path: `system.${accessor}`,
             actor,
             helpedWith: statName,
@@ -84,10 +89,7 @@ export async function handleNpcStatRoll({
             difficulty: 3,
             bonusDice: 0,
             arthaDice: 0,
-            woundDice:
-                ['circles', 'resources', 'health'].indexOf(accessor) === -1
-                    ? actor.system.ptgs.woundDice
-                    : 0,
+            woundDice: woundDice,
             obPenalty:
                 ['circles', 'resources', 'health'].indexOf(accessor) === -1
                     ? actor.system.ptgs.obPenalty

--- a/module/rolls/rollAttribute.ts
+++ b/module/rolls/rollAttribute.ts
@@ -84,7 +84,7 @@ export async function handleAttrRoll({
     if (dataPreset && dataPreset.addHelp) {
         // add a test log instead of testing
         return buildHelpDialog({
-            exponent: stat.exp,
+            exponent: stat.exp - (woundDice ?? 0),
             path: accessor,
             actor,
             helpedWith: attrName,

--- a/module/rolls/rollLearning.ts
+++ b/module/rolls/rollLearning.ts
@@ -99,7 +99,7 @@ async function buildLearningDialog({
     if (dataPreset && dataPreset.addHelp) {
         // add a test log instead of testing
         return buildHelpDialog({
-            exponent: stat.exp,
+            exponent: stat.exp - (actor.system.ptgs.woundDice ?? 0),
             path: `system.${statName}`,
             actor,
             helpedWith: statName,

--- a/module/rolls/rollSkill.ts
+++ b/module/rolls/rollSkill.ts
@@ -52,7 +52,7 @@ export async function handleSkillRoll({
     if (dataPreset && dataPreset.addHelp) {
         // add a test log instead of testing
         return buildHelpDialog({
-            exponent: skill.system.exp,
+            exponent: skill.system.exp - (actor.system.ptgs.woundDice ?? 0),
             skillId: skill.id,
             actor,
             helpedWith: skill.name,

--- a/module/rolls/rollStat.ts
+++ b/module/rolls/rollStat.ts
@@ -46,7 +46,7 @@ export async function handleStatRoll({
     if (dataPreset && dataPreset.addHelp) {
         // add a test log instead of testing
         return buildHelpDialog({
-            exponent: stat.exp,
+            exponent: stat.exp - (actor.system.ptgs.woundDice ?? 0),
             path: accessor,
             actor,
             helpedWith: statName,


### PR DESCRIPTION
## Changes / Comments

Forks and Help should consider wound penalties when determining the bonus they provide (+1D or +2D). 

I made a change to apply the wound penalty to exponents when calculating help and fork, for both PCs and NPCs. Abilities that don't suffer wound penalties should be correctly excluded from this penalty.

## Extra Info

The book isn't completely clear about this behavior, but I believe that the rules as intended is that wounds effectively reduce the exponent of the ability. So I went ahead and asked Luke Crane on Discord (see below; Bluke is Burning Luke).

<img width="1717" height="611" alt="image" src="https://github.com/user-attachments/assets/46894c7c-ee2f-4f4f-9c87-79eb9a77281f" />

Extra information for the fix is also quite helpful. Try to answer any relevant questions in the comment.

-   [ ] Did this PR have to change `template.yml`?
-   [ ] If so, were there any steps taken to protect existing user data? A migration task?
-   [x] Did you follow the [contributing guidelines](https://github.com/StasTserk/foundry-burningwheel/blob/master/CONTRIBUTING.md)?
-   [x] Is this PR limited to fixing just one issue?
