### PR TITLE
Fix advancement for wounded help

### DIFF
--- a/module/dialogs/ModifierDialog.ts
+++ b/module/dialogs/ModifierDialog.ts
@@ -72,7 +72,7 @@ export class ModifierDialog extends Application {
             let diff: TestString = 'Routine';
             const actor = game.actors?.get(entry.actorId) as BWActor;
             const woundDice = (actor as BWCharacter).system.ptgs.woundDice ?? 0;
-            
+
             if (actor.type === 'character') {
                 if (entry.path) {
                     name = entry.path
@@ -83,8 +83,16 @@ export class ModifierDialog extends Application {
                         entry.path.replace('system.', '')
                     ) as Ability & { name?: string };
 
-                    const applyWound = ['circles', 'resources', 'health'].indexOf(name.toLowerCase()) === -1;
-                    const effectiveExp = ability.exp - (applyWound ? woundDice : 0);
+                    const applyWound =
+                        [
+                            'circles',
+                            'resources',
+                            'health',
+                            'custom1',
+                            'custom2',
+                        ].indexOf(name.toLowerCase()) === -1;
+                    const effectiveExp =
+                        ability.exp - (applyWound ? woundDice : 0);
                     diff = difficultyGroup(effectiveExp, obstacle);
                     if (name === 'Custom1' || name === 'Custom2') {
                         name = ability.name || name;
@@ -100,7 +108,10 @@ export class ModifierDialog extends Application {
                     const skill = game.actors
                         ?.get(entry.actorId)
                         ?.items.get(entry.skillId || '') as Skill;
-                    diff = difficultyGroup(skill.system.exp - woundDice, obstacle);
+                    diff = difficultyGroup(
+                        skill.system.exp - woundDice,
+                        obstacle
+                    );
                     skill.addTest(diff);
                     name = skill.name;
                 }

--- a/module/dialogs/ModifierDialog.ts
+++ b/module/dialogs/ModifierDialog.ts
@@ -71,7 +71,8 @@ export class ModifierDialog extends Application {
             let name = '';
             let diff: TestString = 'Routine';
             const actor = game.actors?.get(entry.actorId) as BWActor;
-
+            const woundDice = (actor as BWCharacter).system.ptgs.woundDice ?? 0;
+            
             if (actor.type === 'character') {
                 if (entry.path) {
                     name = entry.path
@@ -81,7 +82,10 @@ export class ModifierDialog extends Application {
                         actor.system,
                         entry.path.replace('system.', '')
                     ) as Ability & { name?: string };
-                    diff = difficultyGroup(ability.exp, obstacle);
+
+                    const applyWound = ['circles', 'resources', 'health'].indexOf(name.toLowerCase()) === -1;
+                    const effectiveExp = ability.exp - (applyWound ? woundDice : 0);
+                    diff = difficultyGroup(effectiveExp, obstacle);
                     if (name === 'Custom1' || name === 'Custom2') {
                         name = ability.name || name;
                     }
@@ -96,7 +100,7 @@ export class ModifierDialog extends Application {
                     const skill = game.actors
                         ?.get(entry.actorId)
                         ?.items.get(entry.skillId || '') as Skill;
-                    diff = difficultyGroup(skill.system.exp, obstacle);
+                    diff = difficultyGroup(skill.system.exp - woundDice, obstacle);
                     skill.addTest(diff);
                     name = skill.name;
                 }

--- a/module/rolls/npcStatRoll.ts
+++ b/module/rolls/npcStatRoll.ts
@@ -68,7 +68,8 @@ export async function handleNpcStatRoll({
         ]);
     }
 
-    const applyWound = ['circles', 'resources', 'health'].indexOf(accessor) === -1;
+    const applyWound =
+        ['circles', 'resources', 'health'].indexOf(accessor) === -1;
     const woundDice = actor.system.ptgs.woundDice ?? 0;
 
     if (dataPreset && dataPreset.addHelp) {

--- a/module/rolls/npcStatRoll.ts
+++ b/module/rolls/npcStatRoll.ts
@@ -68,10 +68,8 @@ export async function handleNpcStatRoll({
         ]);
     }
 
-    const woundDice =
-        ['circles', 'resources', 'health'].indexOf(accessor) === -1
-            ? actor.system.ptgs.woundDice ?? 0
-            : 0;
+    const applyWound = ['circles', 'resources', 'health'].indexOf(accessor) === -1;
+    const woundDice = actor.system.ptgs.woundDice ?? 0;
 
     if (dataPreset && dataPreset.addHelp) {
         // add a test log instead of testing
@@ -89,11 +87,8 @@ export async function handleNpcStatRoll({
             difficulty: 3,
             bonusDice: 0,
             arthaDice: 0,
-            woundDice: woundDice,
-            obPenalty:
-                ['circles', 'resources', 'health'].indexOf(accessor) === -1
-                    ? actor.system.ptgs.obPenalty
-                    : 0,
+            woundDice: applyWound ? woundDice : 0,
+            obPenalty: applyWound ? actor.system.ptgs.obPenalty : 0,
             circlesBonus:
                 accessor === 'circles' ? actor.circlesBonus : undefined,
             circlesMalus:


### PR DESCRIPTION
## Changes / Comments

Follow up fix to #582. I had missed to subtract the wound dice when calculating advancement from helping.

Now it should be correct. Helping while wounded grants advancement as if the stat/skill had lower exponent. 

## Extra Info

-   [ ] Did this PR have to change `template.yml`?
-   [ ] If so, were there any steps taken to protect existing user data? A migration task?
-   [x] Did you follow the [contributing guidelines](https://github.com/StasTserk/foundry-burningwheel/blob/master/CONTRIBUTING.md)?
-   [x] Is this PR limited to fixing just one issue?
