### PR TITLE
Fix conflict with Monk's Active Tiles

### DIFF
--- a/module/burningwheel.ts
+++ b/module/burningwheel.ts
@@ -205,7 +205,7 @@ function registerHelpers() {
     );
 
     Handlebars.registerHelper(
-        'selectGroups',
+        'bwSelectGroups',
         (selected: string, options: TypeMissing): string => {
             const escapedValue = RegExp.escape(
                 Handlebars.escapeExpression(selected)

--- a/templates/dialogs/duel-of-wits.hbs
+++ b/templates/dialogs/duel-of-wits.hbs
@@ -117,7 +117,7 @@
             {{#if showS1Select}}
                 <select class='action-select' name='v1s1' aria-label='side 1 volley 1 select'>
                     <option value='?'>Pick an Option</option>
-                    {{#selectGroups v1s1}}
+                    {{#bwSelectGroups v1s1}}
                         {{#each ../actionOptions as |ao|}}
                             <optgroup label='{{@key}}'>
                                 {{#each ao as |o|}}
@@ -125,7 +125,7 @@
                                 {{/each}}
                             </optgroup>
                         {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             {{/if}}
             {{#if showV1S1Card}}
@@ -149,7 +149,7 @@
             {{#if showS1Select}}
                 <select class='action-select' name='v2s1' aria-label='side 1 volley 2 select'>
                     <option value='?'>Pick an Option</option>
-                    {{#selectGroups v2s1}}
+                    {{#bwSelectGroups v2s1}}
                         {{#each ../actionOptions as |ao|}}
                             <optgroup label='{{@key}}'>
                                 {{#each ao as |o|}}
@@ -157,7 +157,7 @@
                                 {{/each}}
                             </optgroup>
                         {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             {{/if}}
             {{#if showV2S1Card}}
@@ -181,7 +181,7 @@
             {{#if showS1Select}}
                 <select class='action-select' name='v3s1' aria-label='side 1 volley 3 select'>
                     <option value='?'>Pick an Option</option>
-                    {{#selectGroups v3s1}}
+                    {{#bwSelectGroups v3s1}}
                         {{#each ../actionOptions as |ao|}}
                             <optgroup label='{{@key}}'>
                                 {{#each ao as |o|}}
@@ -189,7 +189,7 @@
                                 {{/each}}
                             </optgroup>
                         {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             {{/if}}
             {{#if showV3S1Card}}
@@ -260,7 +260,7 @@
             {{#if showS2Select}}
                 <select class='action-select' name='v1s2' aria-label='side 2 volley 1 select'>
                     <option value='?'>Pick an Option</option>
-                    {{#selectGroups v1s2}}
+                    {{#bwSelectGroups v1s2}}
                         {{#each ../actionOptions as |ao|}}
                             <optgroup label='{{@key}}'>
                                 {{#each ao as |o|}}
@@ -268,7 +268,7 @@
                                 {{/each}}
                             </optgroup>
                         {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             {{/if}}
             {{#if showV1S2Card}}
@@ -281,7 +281,7 @@
             {{#if showS2Select}}
                 <select class='action-select' name='v2s2' aria-label='side 2 volley 2 select'>
                     <option value='?'>Pick an Option</option>
-                    {{#selectGroups v2s2}}
+                    {{#bwSelectGroups v2s2}}
                         {{#each ../actionOptions as |ao|}}
                             <optgroup label='{{@key}}'>
                                 {{#each ao as |o|}}
@@ -289,7 +289,7 @@
                                 {{/each}}
                             </optgroup>
                         {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             {{/if}}
             {{#if showV2S2Card}}
@@ -302,7 +302,7 @@
             {{#if showS2Select}}
                 <select class='action-select' name='v3s2' aria-label='side 2 volley 3 select'>
                     <option value='?'>Pick an Option</option>
-                    {{#selectGroups v3s2}}
+                    {{#bwSelectGroups v3s2}}
                         {{#each ../actionOptions as |ao|}}
                             <optgroup label='{{@key}}'>
                                 {{#each ao as |o|}}
@@ -310,7 +310,7 @@
                                 {{/each}}
                             </optgroup>
                         {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             {{/if}}
             {{#if showV3S2Card}}

--- a/templates/dialogs/fight.hbs
+++ b/templates/dialogs/fight.hbs
@@ -139,7 +139,7 @@
             {{#if p.showActions}}
             <label>Action 1
                 <select name="action1" data-index="{{i}}">
-                    {{#selectGroups p.action1}}
+                    {{#bwSelectGroups p.action1}}
                     {{#if p.action2}}{{else}}<option value="">Do Nothing</option>{{/if}}
                     {{#each ../../actionOptions as |ao|}}
                     <optgroup label="{{@key}}">
@@ -148,13 +148,13 @@
                         {{/each}}
                     </optgroup>
                     {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             </label>
             {{#if p.showAction2}}
             <label>Action 2
                 <select name="action2" data-index="{{i}}">
-                    {{#selectGroups p.action2}}
+                    {{#bwSelectGroups p.action2}}
                     {{#if p.action3}}{{else}}<option value="">Do Nothing</option>{{/if}}
                     {{#each ../../actionOptions as |ao|}}
                     <optgroup label="{{@key}}">
@@ -163,14 +163,14 @@
                         {{/each}}
                     </optgroup>
                     {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             </label>
             {{/if}}
             {{#if p.showAction3}}
             <label>Action 3
                 <select name="action3" data-index="{{i}}">
-                    {{#selectGroups p.action3}}
+                    {{#bwSelectGroups p.action3}}
                     <option value="">Do Nothing</option>
                     {{#each ../../actionOptions as |ao|}}
                     <optgroup label="{{@key}}">
@@ -179,7 +179,7 @@
                         {{/each}}
                     </optgroup>
                     {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             </label>
             {{/if}}
@@ -189,7 +189,7 @@
             {{#if p.showActions}}
             <label>Action 1
                 <select name="action4" data-index="{{i}}">
-                    {{#selectGroups p.action4}}
+                    {{#bwSelectGroups p.action4}}
                     {{#if p.action5}}{{else}}<option value="">Do Nothing</option>{{/if}}
                     {{#each ../../actionOptions as |ao|}}
                     <optgroup label="{{@key}}">
@@ -198,13 +198,13 @@
                         {{/each}}
                     </optgroup>
                     {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             </label>
             {{#if p.showAction5}}
             <label>Action 2
                 <select name="action5" data-index="{{i}}">
-                    {{#selectGroups p.action5}}
+                    {{#bwSelectGroups p.action5}}
                     {{#if p.action6}}{{else}}<option value="">Do Nothing</option>{{/if}}
                     {{#each ../../actionOptions as |ao|}}
                     <optgroup label="{{@key}}">
@@ -213,14 +213,14 @@
                         {{/each}}
                     </optgroup>
                     {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             </label>
             {{/if}}
             {{#if p.showAction6}}
             <label>Action 3
                 <select name="action6" data-index="{{i}}">
-                    {{#selectGroups p.action6}}
+                    {{#bwSelectGroups p.action6}}
                     <option value="">Do Nothing</option>
                     {{#each ../../actionOptions as |ao|}}
                     <optgroup label="{{@key}}">
@@ -229,7 +229,7 @@
                         {{/each}}
                     </optgroup>
                     {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             </label>
             {{/if}}
@@ -239,7 +239,7 @@
             {{#if p.showActions}}
             <label>Action 1
                 <select name="action7" data-index="{{i}}">
-                    {{#selectGroups p.action7}}
+                    {{#bwSelectGroups p.action7}}
                     {{#if p.action8}}{{else}}<option value="">Do Nothing</option>{{/if}}
                     {{#each ../../actionOptions as |ao|}}
                     <optgroup label="{{@key}}">
@@ -248,13 +248,13 @@
                         {{/each}}
                     </optgroup>
                     {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             </label>
             {{#if p.showAction8}}
             <label>Action 2
                 <select name="action8" data-index="{{i}}">
-                    {{#selectGroups p.action8}}
+                    {{#bwSelectGroups p.action8}}
                     {{#if p.action9}}{{else}}<option value="">Do Nothing</option>{{/if}}
                     {{#each ../../actionOptions as |ao|}}
                     <optgroup label="{{@key}}">
@@ -263,14 +263,14 @@
                         {{/each}}
                     </optgroup>
                     {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             </label>
             {{/if}}
             {{#if p.showAction9}}
             <label>Action 3
                 <select name="action9" data-index="{{i}}">
-                    {{#selectGroups p.action9}}
+                    {{#bwSelectGroups p.action9}}
                     <option value="">Do Nothing</option>
                     {{#each ../../actionOptions as |ao|}}
                     <optgroup label="{{@key}}">
@@ -279,7 +279,7 @@
                         {{/each}}
                     </optgroup>
                     {{/each}}
-                    {{/selectGroups}}
+                    {{/bwSelectGroups}}
                 </select>
             </label>
             {{/if}}

--- a/templates/dialogs/range-and-cover.hbs
+++ b/templates/dialogs/range-and-cover.hbs
@@ -87,7 +87,7 @@
             {{#if t.editable}}
             <select name="action1" data-index="{{i}}">
                 <option value="Do Nothing">Do Nothing</option>
-                {{#selectGroups t.action1}}
+                {{#bwSelectGroups t.action1}}
                 {{#each @root.actionOptions as |ao|}}
                 <optgroup label="{{@key}}">
                     {{#each ao as |o|}}
@@ -95,7 +95,7 @@
                     {{/each}}
                 </optgroup>
                 {{/each}}
-                {{/selectGroups}}
+                {{/bwSelectGroups}}
             </select>
             {{/if}}
             {{#if t.showAction1}}
@@ -108,7 +108,7 @@
             {{#if t.editable}}
             <select name="action2" data-index="{{i}}">
                 <option value="Do Nothing">Do Nothing</option>
-                {{#selectGroups t.action2}}
+                {{#bwSelectGroups t.action2}}
                 {{#each @root.actionOptions as |ao|}}
                 <optgroup label="{{@key}}">
                     {{#each ao as |o|}}
@@ -116,7 +116,7 @@
                     {{/each}}
                 </optgroup>
                 {{/each}}
-                {{/selectGroups}}
+                {{/bwSelectGroups}}
             </select>
             {{/if}}
             {{#if t.showAction2}}
@@ -129,7 +129,7 @@
             {{#if t.editable}}
             <select name="action3" data-index="{{i}}">
                 <option value="Do Nothing">Do Nothing</option>
-                {{#selectGroups t.action3}}
+                {{#bwSelectGroups t.action3}}
                 {{#each @root.actionOptions as |ao|}}
                 <optgroup label="{{@key}}">
                     {{#each ao as |o|}}
@@ -137,7 +137,7 @@
                     {{/each}}
                 </optgroup>
                 {{/each}}
-                {{/selectGroups}}
+                {{/bwSelectGroups}}
             </select>
             {{/if}}
             {{#if t.showAction3}}


### PR DESCRIPTION
## Changes / Comments
Mentioned in #574 

Monk's Active Tiles registers its own `selectGroups` Handlebars helper, which loads after BW's and overwrites it.
This fix renames the helper to `bwSelectGroups` to avoid the collision altogether.

## Extra Info

Extra information for the fix is also quite helpful. Try to answer any relevant questions in the comment.

-   [ ] Did this PR have to change `template.yml`?
-   [ ] If so, were there any steps taken to protect existing user data? A migration task?
-   [x] Did you follow the [contributing guidelines](https://github.com/StasTserk/foundry-burningwheel/blob/master/CONTRIBUTING.md)?
-   [x] Is this PR limited to fixing just one issue?
